### PR TITLE
Expose the cargo crate feature: vendored-openssl.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "miow",
  "num_cpus",
  "opener",
+ "openssl",
  "percent-encoding",
  "remove_dir_all",
  "rustc-workspace-hack",
@@ -185,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-geiger"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "better-panic",
@@ -529,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "geiger"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -879,6 +880,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.8.1+1.1.1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04f0299a91de598dde58d2e99101895498dcf3d58896a3297798f28b27c8b72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +897,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/README.md
+++ b/README.md
@@ -11,13 +11,24 @@ This cargo plugin is based on the code from two other projects:
 <https://github.com/icefoxen/cargo-osha> and
 <https://github.com/sfackler/cargo-tree>.
 
+Installation
+------------
+
+Try to find and use a system-wide installed OpenSSL library:
+```
+cargo install cargo-geiger
+```
+
+Or, build and statically link OpenSSL as part of the cargo-geiger executable:
+```
+cargo install cargo-geiger --features vendored-openssl
+```
 
 Usage
 -----
 
-1. `cargo install cargo-geiger`
-2. Navigate to the same directory as the `Cargo.toml` you want to analyze.
-3. `cargo geiger`
+1. Navigate to the same directory as the `Cargo.toml` you want to analyze.
+2. `cargo geiger`
 
 
 Output example

--- a/cargo-geiger/Cargo.toml
+++ b/cargo-geiger/Cargo.toml
@@ -25,8 +25,7 @@ pico-args = "0.3.1"
 walkdir = "2.3.1"
 
 [features]
-default = ["cargo-vendored-openssl"]
-cargo-vendored-openssl = ["cargo/vendored-openssl"]
+vendored-openssl = ["cargo/vendored-openssl"]
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/cargo-geiger/Cargo.toml
+++ b/cargo-geiger/Cargo.toml
@@ -24,6 +24,10 @@ petgraph = "0.5.0"
 pico-args = "0.3.1"
 walkdir = "2.3.1"
 
+[features]
+default = ["cargo-vendored-openssl"]
+cargo-vendored-openssl = ["cargo/vendored-openssl"]
+
 [dev-dependencies]
 assert_cmd = "1.0.1"
 better-panic = "0.2.0"


### PR DESCRIPTION
Fixes: #97 

Is this an acceptable solution? For macOS this seems like the right choice to me. If this PR passes the CI build I'm fine with using the vendored-openssl feature for all platforms.