### PR TITLE
ISSUE-16 - Add unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,8 +201,11 @@ dependencies = [
  "insta",
  "petgraph",
  "pico-args",
+ "rand",
  "regex",
  "rstest",
+ "strum",
+ "strum_macros",
  "walkdir",
 ]
 
@@ -589,6 +592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1259,6 +1271,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strum"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3924a58d165da3b7b2922c667ab0673c7b5fd52b5c19ea3442747bcb3cd15abe"
+
+[[package]]
+name = "strum_macros"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2ab682ecdcae7f5f45ae85cd7c1e6c8e68ea42c8a612d47fedf831c037146a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1414,12 @@ checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"

--- a/cargo-geiger/Cargo.toml
+++ b/cargo-geiger/Cargo.toml
@@ -22,6 +22,8 @@ env_logger = "0.7.1"
 geiger = { path = "../geiger", version = "0.4.5" }
 petgraph = "0.5.1"
 pico-args = "0.3.3"
+strum = "0.19.2"
+strum_macros = "0.19.2"
 walkdir = "2.3.1"
 anyhow = "1.0.31"
 
@@ -32,5 +34,6 @@ vendored-openssl = ["cargo/vendored-openssl"]
 assert_cmd = "1.0.1"
 better-panic = "0.2.0"
 insta = "0.16.1"
+rand = "0.7.3"
 regex = "1.3.9"
 rstest = "0.6.4"

--- a/cargo-geiger/src/format/print.rs
+++ b/cargo-geiger/src/format/print.rs
@@ -7,9 +7,9 @@ use petgraph::EdgeDirection;
 
 #[derive(Clone, Copy)]
 pub enum Prefix {
-    None,
-    Indent,
     Depth,
+    Indent,
+    None,
 }
 
 pub struct PrintConfig<'a> {
@@ -30,12 +30,43 @@ pub struct PrintConfig<'a> {
 }
 
 pub fn colorize(
-    s: String,
-    detection_status: &CrateDetectionStatus,
+    string: String,
+    crate_detection_status: &CrateDetectionStatus,
 ) -> colored::ColoredString {
-    match detection_status {
-        CrateDetectionStatus::NoneDetectedForbidsUnsafe => s.green(),
-        CrateDetectionStatus::NoneDetectedAllowsUnsafe => s.normal(),
-        CrateDetectionStatus::UnsafeDetected => s.red().bold(),
+    match crate_detection_status {
+        CrateDetectionStatus::NoneDetectedForbidsUnsafe => string.green(),
+        CrateDetectionStatus::NoneDetectedAllowsUnsafe => string.normal(),
+        CrateDetectionStatus::UnsafeDetected => string.red().bold(),
+    }
+}
+
+#[cfg(test)]
+mod print_tests {
+    use super::*;
+
+    #[test]
+    fn colorize_test() {
+        let string = String::from("string_value");
+
+        assert_eq!(
+            string.clone().green(),
+            colorize(
+                string.clone(),
+                &CrateDetectionStatus::NoneDetectedForbidsUnsafe
+            )
+        );
+
+        assert_eq!(
+            string.clone().normal(),
+            colorize(
+                string.clone(),
+                &CrateDetectionStatus::NoneDetectedAllowsUnsafe
+            )
+        );
+
+        assert_eq!(
+            string.clone().red().bold(),
+            colorize(string.clone(), &CrateDetectionStatus::UnsafeDetected)
+        );
     }
 }

--- a/cargo-geiger/src/format/table.rs
+++ b/cargo-geiger/src/format/table.rs
@@ -1,7 +1,9 @@
 use crate::find::GeigerContext;
 use crate::format::print::{colorize, PrintConfig};
 use crate::format::tree::TextTreeLine;
-use crate::format::{CrateDetectionStatus, get_kind_group_name, EmojiSymbols, SymbolKind};
+use crate::format::{
+    get_kind_group_name, CrateDetectionStatus, EmojiSymbols, SymbolKind,
+};
 use crate::rs_file::PackageMetrics;
 
 use cargo::core::package::PackageSet;
@@ -21,23 +23,22 @@ pub const UNSAFE_COUNTERS_HEADER: [&str; 6] = [
     "Dependency",
 ];
 
-pub fn print_text_tree_lines_as_table(
+pub fn create_table_from_text_tree_lines(
     geiger_context: &GeigerContext,
     package_set: &PackageSet,
     print_config: &PrintConfig,
     rs_files_used: &HashSet<PathBuf>,
     text_tree_lines: Vec<TextTreeLine>,
-) -> u64 {
-    let mut total_packs_none_detected_forbids_unsafe = 0;
-    let mut total_packs_none_detected_allows_unsafe = 0;
-    let mut total_packs_unsafe_detected = 0;
+) -> (Vec<String>, u64) {
+    let mut table_lines = Vec::<String>::new();
+
+    let mut total_package_counts = TotalPackageCounts::new();
+
     let mut package_status = HashMap::new();
-    let mut total = CounterBlock::default();
-    let mut total_unused = CounterBlock::default();
     let mut warning_count = 0;
 
-    for tl in text_tree_lines {
-        match tl {
+    for text_tree_line in text_tree_lines {
+        match text_tree_line {
             TextTreeLine::Package { id, tree_vines } => {
                 let pack = package_set.get_one(id).unwrap_or_else(|_| {
                     // TODO: Avoid panic, return Result.
@@ -74,36 +75,43 @@ pub fn print_text_tree_lines_as_table(
                         .filter(|(_, v)| v.is_crate_entry_point)
                         .all(|(_, v)| v.metrics.forbids_unsafe);
 
-                    for (k, v) in &pack_metrics.rs_path_to_metrics {
-                        //println!("{}", k.display());
-                        let target = if rs_files_used.contains(k) {
-                            &mut total
+                    for (path_buf, rs_file_metrics_wrapper) in
+                        &pack_metrics.rs_path_to_metrics
+                    {
+                        let target = if rs_files_used.contains(path_buf) {
+                            &mut total_package_counts.total_counter_block
                         } else {
-                            &mut total_unused
+                            &mut total_package_counts.total_unused_counter_block
                         };
-                        *target = target.clone() + v.metrics.counters.clone();
+                        *target = target.clone()
+                            + rs_file_metrics_wrapper.metrics.counters.clone();
                     }
+
                     match (unsafe_found, crate_forbids_unsafe) {
                         (false, true) => {
-                            total_packs_none_detected_forbids_unsafe += 1;
+                            total_package_counts
+                                .none_detected_forbids_unsafe += 1;
                             CrateDetectionStatus::NoneDetectedForbidsUnsafe
                         }
                         (false, false) => {
-                            total_packs_none_detected_allows_unsafe += 1;
+                            total_package_counts.none_detected_allows_unsafe +=
+                                1;
                             CrateDetectionStatus::NoneDetectedAllowsUnsafe
                         }
                         (true, _) => {
-                            total_packs_unsafe_detected += 1;
+                            total_package_counts.unsafe_detected += 1;
                             CrateDetectionStatus::UnsafeDetected
                         }
                     }
                 });
+
                 let emoji_symbols = EmojiSymbols::new(print_config.charset);
-                let detection_status =
+
+                let crate_detection_status =
                     package_status.get(&id).unwrap_or_else(|| {
                         panic!("Expected to find package by id: {}", &id)
                     });
-                let icon = match detection_status {
+                let icon = match crate_detection_status {
                     CrateDetectionStatus::NoneDetectedForbidsUnsafe => {
                         emoji_symbols.emoji(SymbolKind::Lock)
                     }
@@ -114,21 +122,27 @@ pub fn print_text_tree_lines_as_table(
                         emoji_symbols.emoji(SymbolKind::Rads)
                     }
                 };
-                let pack_name = colorize(
+
+                let package_name = colorize(
                     format!(
                         "{}",
                         print_config
                             .format
                             .display(&id, pack.manifest().metadata())
                     ),
-                    &detection_status,
+                    &crate_detection_status,
                 );
                 let unsafe_info = colorize(
                     table_row(&pack_metrics, &rs_files_used),
-                    &detection_status,
+                    &crate_detection_status,
                 );
+
                 let shift_chars = unsafe_info.chars().count() + 4;
-                print!("{}  {: <2}", unsafe_info, icon);
+
+                let mut line = String::new();
+                line.push_str(
+                    format!("{}  {: <2}", unsafe_info, icon).as_str(),
+                );
 
                 // Here comes some special control characters to position the cursor
                 // properly for printing the last column containing the tree vines, after
@@ -138,11 +152,12 @@ pub fn print_text_tree_lines_as_table(
                 // Rust. This could be unrelated to Rust and a quirk of this particular
                 // symbol or something in the Terminal app on macOS.
                 if emoji_symbols.will_output_emoji() {
-                    print!("\r"); // Return the cursor to the start of the line.
-                    print!("\x1B[{}C", shift_chars); // Move the cursor to the right so that it points to the icon character.
+                    line.push_str("\r"); // Return the cursor to the start of the line.
+                    line.push_str(format!("\x1B[{}C", shift_chars).as_str()); // Move the cursor to the right so that it points to the icon character.
                 }
 
-                println!(" {}{}", tree_vines, pack_name);
+                table_lines
+                    .push(format!("{} {}{}", line, tree_vines, package_name))
             }
             TextTreeLine::ExtraDepsGroup { kind, tree_vines } => {
                 let name = get_kind_group_name(kind);
@@ -152,27 +167,66 @@ pub fn print_text_tree_lines_as_table(
                 let name = name.unwrap();
 
                 // TODO: Fix the alignment on macOS (others too?)
-                println!("{}{}{}", table_row_empty(), tree_vines, name);
+                table_lines.push(format!(
+                    "{}{}{}",
+                    table_row_empty(),
+                    tree_vines,
+                    name
+                ))
             }
         }
     }
 
-    println!();
-    let total_detection_status = match (
-        total_packs_none_detected_forbids_unsafe > 0,
-        total_packs_none_detected_allows_unsafe > 0,
-        total_packs_unsafe_detected > 0,
-    ) {
-        (_, _, true) => CrateDetectionStatus::UnsafeDetected,
-        (true, false, false) => CrateDetectionStatus::NoneDetectedForbidsUnsafe,
-        _ => CrateDetectionStatus::NoneDetectedAllowsUnsafe,
-    };
-    println!(
-        "{}",
-        table_footer(total, total_unused, total_detection_status)
-    );
+    table_lines.push(String::new());
+    let total_detection_status =
+        total_package_counts.get_total_detection_status();
 
-    warning_count
+    table_lines.push(format!(
+        "{}",
+        table_footer(
+            total_package_counts.total_counter_block,
+            total_package_counts.total_unused_counter_block,
+            total_detection_status
+        )
+    ));
+
+    table_lines.push(String::new());
+
+    (table_lines, warning_count)
+}
+
+struct TotalPackageCounts {
+    none_detected_forbids_unsafe: i32,
+    none_detected_allows_unsafe: i32,
+    unsafe_detected: i32,
+    total_counter_block: CounterBlock,
+    total_unused_counter_block: CounterBlock,
+}
+
+impl TotalPackageCounts {
+    fn new() -> TotalPackageCounts {
+        TotalPackageCounts {
+            none_detected_forbids_unsafe: 0,
+            none_detected_allows_unsafe: 0,
+            unsafe_detected: 0,
+            total_counter_block: CounterBlock::default(),
+            total_unused_counter_block: CounterBlock::default(),
+        }
+    }
+
+    fn get_total_detection_status(&self) -> CrateDetectionStatus {
+        match (
+            self.none_detected_forbids_unsafe > 0,
+            self.none_detected_allows_unsafe > 0,
+            self.unsafe_detected > 0,
+        ) {
+            (_, _, true) => CrateDetectionStatus::UnsafeDetected,
+            (true, false, false) => {
+                CrateDetectionStatus::NoneDetectedForbidsUnsafe
+            }
+            _ => CrateDetectionStatus::NoneDetectedAllowsUnsafe,
+        }
+    }
 }
 
 fn table_footer(
@@ -197,13 +251,14 @@ fn table_footer(
 fn table_row(pms: &PackageMetrics, rs_files_used: &HashSet<PathBuf>) -> String {
     let mut used = CounterBlock::default();
     let mut not_used = CounterBlock::default();
-    for (k, v) in pms.rs_path_to_metrics.iter() {
-        let target = if rs_files_used.contains(k) {
+    for (path_buf, rs_file_metrics_wrapper) in pms.rs_path_to_metrics.iter() {
+        let target = if rs_files_used.contains(path_buf) {
             &mut used
         } else {
             &mut not_used
         };
-        *target = target.clone() + v.metrics.counters.clone();
+        *target =
+            target.clone() + rs_file_metrics_wrapper.metrics.counters.clone();
     }
     let fmt = |used: &Count, not_used: &Count| {
         format!("{}/{}", used.unsafe_, used.unsafe_ + not_used.unsafe_)
@@ -228,4 +283,162 @@ fn table_row_empty() -> String {
             + UNSAFE_COUNTERS_HEADER.len()
             + 1,
     )
+}
+
+#[cfg(test)]
+mod table_tests {
+    use super::*;
+
+    use crate::rs_file::RsFileMetricsWrapper;
+
+    use geiger::RsFileMetrics;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn table_footer_test() {
+        let used_counter_block = create_counter_block();
+        let not_used_counter_block = create_counter_block();
+
+        let expected_line =
+            String::from("2/4        4/8          6/12   8/16    10/20  ");
+
+        for crate_detection_status in CrateDetectionStatus::iter() {
+            let table_footer = table_footer(
+                used_counter_block.clone(),
+                not_used_counter_block.clone(),
+                crate_detection_status.clone(),
+            );
+
+            assert_eq!(
+                table_footer,
+                colorize(expected_line.clone(), &crate_detection_status)
+            );
+        }
+    }
+
+    #[test]
+    fn table_row_test() {
+        let mut rs_path_to_metrics =
+            HashMap::<PathBuf, RsFileMetricsWrapper>::new();
+
+        rs_path_to_metrics.insert(
+            Path::new("package_1_path").to_path_buf(),
+            create_rs_file_metrics_wrapper(true, true),
+        );
+
+        rs_path_to_metrics.insert(
+            Path::new("package_2_path").to_path_buf(),
+            create_rs_file_metrics_wrapper(true, false),
+        );
+
+        rs_path_to_metrics.insert(
+            Path::new("package_3_path").to_path_buf(),
+            create_rs_file_metrics_wrapper(false, false),
+        );
+
+        let package_metrics = PackageMetrics { rs_path_to_metrics };
+
+        let rs_files_used: HashSet<PathBuf> = [
+            Path::new("package_1_path").to_path_buf(),
+            Path::new("package_3_path").to_path_buf(),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        let table_row = table_row(&package_metrics, &rs_files_used);
+        assert_eq!(table_row, "4/6        8/12         12/18  16/24   20/30  ");
+    }
+
+    #[test]
+    fn table_row_empty_test() {
+        let empty_table_row = table_row_empty();
+        assert_eq!(empty_table_row.len(), 50);
+    }
+
+    #[test]
+    fn total_package_counts_get_total_detection_status_tests() {
+        let total_package_counts_unsafe_detected = TotalPackageCounts {
+            none_detected_forbids_unsafe: 0,
+            none_detected_allows_unsafe: 0,
+            unsafe_detected: 1,
+            total_counter_block: CounterBlock::default(),
+            total_unused_counter_block: CounterBlock::default(),
+        };
+
+        assert_eq!(
+            total_package_counts_unsafe_detected.get_total_detection_status(),
+            CrateDetectionStatus::UnsafeDetected
+        );
+
+        let total_package_counts_none_detected_forbids_unsafe =
+            TotalPackageCounts {
+                none_detected_forbids_unsafe: 1,
+                none_detected_allows_unsafe: 0,
+                unsafe_detected: 0,
+                total_counter_block: CounterBlock::default(),
+                total_unused_counter_block: CounterBlock::default(),
+            };
+
+        assert_eq!(
+            total_package_counts_none_detected_forbids_unsafe
+                .get_total_detection_status(),
+            CrateDetectionStatus::NoneDetectedForbidsUnsafe
+        );
+
+        let total_package_counts_none_detected_allows_unsafe =
+            TotalPackageCounts {
+                none_detected_forbids_unsafe: 4,
+                none_detected_allows_unsafe: 1,
+                unsafe_detected: 0,
+                total_counter_block: CounterBlock::default(),
+                total_unused_counter_block: CounterBlock::default(),
+            };
+
+        assert_eq!(
+            total_package_counts_none_detected_allows_unsafe
+                .get_total_detection_status(),
+            CrateDetectionStatus::NoneDetectedAllowsUnsafe
+        );
+    }
+
+    fn create_rs_file_metrics_wrapper(
+        forbids_unsafe: bool,
+        is_crate_entry_point: bool,
+    ) -> RsFileMetricsWrapper {
+        RsFileMetricsWrapper {
+            metrics: RsFileMetrics {
+                counters: create_counter_block(),
+                forbids_unsafe,
+            },
+            is_crate_entry_point,
+        }
+    }
+
+    fn create_counter_block() -> CounterBlock {
+        CounterBlock {
+            functions: Count {
+                safe: 1,
+                unsafe_: 2,
+            },
+            exprs: Count {
+                safe: 3,
+                unsafe_: 4,
+            },
+            item_impls: Count {
+                safe: 5,
+                unsafe_: 6,
+            },
+            item_traits: Count {
+                safe: 7,
+                unsafe_: 8,
+            },
+            methods: Count {
+                safe: 9,
+                unsafe_: 10,
+            },
+        }
+    }
 }

--- a/cargo-geiger/src/format/tree.rs
+++ b/cargo-geiger/src/format/tree.rs
@@ -8,11 +8,12 @@ use cargo::core::PackageId;
 pub enum TextTreeLine {
     /// A text line for a package
     Package { id: PackageId, tree_vines: String },
-    /// There're extra dependencies comming and we should print a group header,
+    /// There are extra dependencies coming and we should print a group header,
     /// eg. "[build-dependencies]".
     ExtraDepsGroup { kind: DepKind, tree_vines: String },
 }
 
+#[derive(Debug, PartialEq)]
 pub struct TreeSymbols {
     pub down: &'static str,
     pub tee: &'static str,
@@ -20,8 +21,8 @@ pub struct TreeSymbols {
     pub right: &'static str,
 }
 
-pub fn get_tree_symbols(cs: Charset) -> TreeSymbols {
-    match cs {
+pub fn get_tree_symbols(charset: Charset) -> TreeSymbols {
+    match charset {
         Charset::Utf8 => UTF8_TREE_SYMBOLS,
         Charset::Ascii => ASCII_TREE_SYMBOLS,
     }
@@ -40,3 +41,13 @@ const UTF8_TREE_SYMBOLS: TreeSymbols = TreeSymbols {
     ell: "└",
     right: "─",
 };
+
+#[cfg(test)]
+mod tree_tests {
+    use super::*;
+
+    #[test]
+    fn get_tree_symbols_test() {
+        assert_eq!(get_tree_symbols(Charset::Utf8), UTF8_TREE_SYMBOLS);
+    }
+}

--- a/cargo-geiger/src/main.rs
+++ b/cargo-geiger/src/main.rs
@@ -7,6 +7,8 @@
 extern crate cargo;
 extern crate colored;
 extern crate petgraph;
+extern crate strum;
+extern crate strum_macros;
 
 mod cli;
 mod find;
@@ -16,21 +18,15 @@ mod rs_file;
 mod scan;
 mod traversal;
 
-use crate::cli::get_cfgs;
-use crate::cli::get_registry;
-use crate::cli::get_workspace;
-use crate::cli::resolve;
-use crate::format::print::Prefix;
-use crate::format::print::PrintConfig;
+use crate::cli::{get_cfgs, get_registry, get_workspace, resolve};
+use crate::format::print::{Prefix, PrintConfig};
 use crate::format::{Charset, Pattern};
-use crate::graph::build_graph;
-use crate::graph::ExtraDeps;
+use crate::graph::{build_graph, ExtraDeps};
 use crate::scan::{run_scan_mode_default, run_scan_mode_forbid_only};
 
-use cargo::core::shell::{Shell, Verbosity};
+use cargo::core::shell::{ColorChoice, Shell, Verbosity};
 use cargo::util::errors::CliError;
-use cargo::CliResult;
-use cargo::Config;
+use cargo::{CliResult, Config};
 use geiger::IncludeTests;
 use petgraph::EdgeDirection;
 use std::fmt;
@@ -182,8 +178,6 @@ impl fmt::Display for FormatError {
 }
 
 fn real_main(args: &Args, config: &mut Config) -> CliResult {
-    use cargo::core::shell::ColorChoice;
-
     if args.version {
         println!("cargo-geiger {}", VERSION.unwrap_or("unknown version"));
         return Ok(());
@@ -301,7 +295,7 @@ fn real_main(args: &Args, config: &mut Config) -> CliResult {
     } else {
         IncludeTests::No
     };
-    let pc = PrintConfig {
+    let print_config = PrintConfig {
         all: args.all,
         verbosity,
         direction,
@@ -313,7 +307,13 @@ fn real_main(args: &Args, config: &mut Config) -> CliResult {
     };
 
     if args.forbid_only {
-        run_scan_mode_forbid_only(&config, &packages, root_pack_id, &graph, &pc)
+        run_scan_mode_forbid_only(
+            &config,
+            &packages,
+            root_pack_id,
+            &graph,
+            &print_config,
+        )
     } else {
         run_scan_mode_default(
             &config,
@@ -321,7 +321,7 @@ fn real_main(args: &Args, config: &mut Config) -> CliResult {
             &packages,
             root_pack_id,
             &graph,
-            &pc,
+            &print_config,
             &args,
         )
     }


### PR DESCRIPTION
Add unit testing to several of the newly refactored modules, ahead of
migrating to use cargo_metadata

Unit tests added to:
* cli
* format - print
* format - table
* format - tree
* format
* graph
* rs_file
* scan
* traversal