### PR TITLE
Fix tree vine on dependency group line

### DIFF
--- a/cargo-geiger/src/format/table.rs
+++ b/cargo-geiger/src/format/table.rs
@@ -228,15 +228,15 @@ fn table_row(
 }
 
 fn table_row_empty() -> String {
-    " ".repeat(
-        UNSAFE_COUNTERS_HEADER
-            .iter()
-            .take(5)
-            .map(|s| s.len())
-            .sum::<usize>()
-            + UNSAFE_COUNTERS_HEADER.len()
-            + 1,
-    )
+    let headers_but_last = &UNSAFE_COUNTERS_HEADER[..UNSAFE_COUNTERS_HEADER.len() - 1];
+    let n = headers_but_last
+        .iter()
+        .map(|s| s.len())
+        .sum::<usize>()
+        + headers_but_last.len() // Space after each column
+        + 2 // Unsafety symbol width
+        + 1; // Space after symbol
+    " ".repeat(n)
 }
 
 #[cfg(test)]

--- a/cargo-geiger/src/format/table.rs
+++ b/cargo-geiger/src/format/table.rs
@@ -309,7 +309,7 @@ mod table_tests {
     #[test]
     fn table_row_empty_test() {
         let empty_table_row = table_row_empty();
-        assert_eq!(empty_table_row.len(), 50);
+        assert_eq!(empty_table_row.len(), 51);
     }
 
     #[test]


### PR DESCRIPTION
The indentation was off. Tested on Linux. I don't have a Mac to test.
Before:
```
2/2        75/75        4/4    1/1     1/1      !  ├── petgraph 0.5.1
0/0        62/62        0/0    0/0     0/0      !  │   ├── fixedbitset 0.2.0
0/0        88/93        1/1    0/0     2/2      !  │   └── indexmap 1.5.0
2/2        954/1048     16/19  0/0     34/38    !  │       └── hashbrown 0.8.1
                                                  │           [build-dependencies]
0/0        0/0          0/0    0/0     0/0      ?  │           └── autocfg 1.0.0
                                                  │       [build-dependencies]
0/0        0/0          0/0    0/0     0/0      ?  │       └── autocfg 1.0.0
```

After:
```
2/2        75/75        4/4    1/1     1/1      !  ├── petgraph 0.5.1
0/0        62/62        0/0    0/0     0/0      !  │   ├── fixedbitset 0.2.0
0/0        88/93        1/1    0/0     2/2      !  │   └── indexmap 1.5.0
2/2        954/1048     16/19  0/0     34/38    !  │       └── hashbrown 0.8.1
                                                   │           [build-dependencies]
0/0        0/0          0/0    0/0     0/0      ?  │           └── autocfg 1.0.0
                                                   │       [build-dependencies]
0/0        0/0          0/0    0/0     0/0      ?  │       └── autocfg 1.0.0
```