### PR TITLE
ISSUE-16 - Remove cargo core usage from graph module:

### DIFF
--- a/cargo-geiger/src/args.rs
+++ b/cargo-geiger/src/args.rs
@@ -58,12 +58,9 @@ OPTIONS:
 #[derive(Default)]
 pub struct Args {
     pub all: bool,
-    pub all_deps: bool,
-    pub all_targets: bool,
-    pub build_deps: bool,
     pub charset: Charset,
     pub color: Option<String>,
-    pub dev_deps: bool,
+    pub deps_args: DepsArgs,
     pub features_args: FeaturesArgs,
     pub forbid_only: bool,
     pub format: String,
@@ -78,7 +75,7 @@ pub struct Args {
     pub package: Option<String>,
     pub prefix_depth: bool,
     pub quiet: bool,
-    pub target: Option<String>,
+    pub target_args: TargetArgs,
     pub unstable_flags: Vec<String>,
     pub verbose: u32,
     pub version: bool,
@@ -91,14 +88,15 @@ impl Args {
     ) -> Result<Args, Box<dyn std::error::Error>> {
         let args = Args {
             all: raw_args.contains(["-a", "--all"]),
-            all_deps: raw_args.contains("--all-dependencies"),
-            all_targets: raw_args.contains("--all-targets"),
-            build_deps: raw_args.contains("--build-dependencies"),
             charset: raw_args
                 .opt_value_from_str("--charset")?
                 .unwrap_or(Charset::Utf8),
             color: raw_args.opt_value_from_str("--color")?,
-            dev_deps: raw_args.contains("--dev-dependencies"),
+            deps_args: DepsArgs {
+                all_deps: raw_args.contains("--all-dependencies"),
+                build_deps: raw_args.contains("--build-dependencies"),
+                dev_deps: raw_args.contains("--dev-dependencies"),
+            },
             features_args: FeaturesArgs {
                 all_features: raw_args.contains("--all-features"),
                 features: parse_features(
@@ -121,7 +119,10 @@ impl Args {
             package: raw_args.opt_value_from_str("--manifest-path")?,
             prefix_depth: raw_args.contains("--prefix-depth"),
             quiet: raw_args.contains(["-q", "--quiet"]),
-            target: raw_args.opt_value_from_str("--target")?,
+            target_args: TargetArgs {
+                all_targets: raw_args.contains("--all-targets"),
+                target: raw_args.opt_value_from_str("--target")?,
+            },
             unstable_flags: raw_args
                 .opt_value_from_str("-Z")?
                 .map(|s: String| s.split(' ').map(|s| s.to_owned()).collect())
@@ -146,10 +147,23 @@ impl Args {
 }
 
 #[derive(Default)]
+pub struct DepsArgs {
+    pub all_deps: bool,
+    pub build_deps: bool,
+    pub dev_deps: bool,
+}
+
+#[derive(Default)]
 pub struct FeaturesArgs {
     pub all_features: bool,
     pub features: Vec<String>,
     pub no_default_features: bool,
+}
+
+#[derive(Default)]
+pub struct TargetArgs {
+    pub all_targets: bool,
+    pub target: Option<String>,
 }
 
 fn parse_features(raw_features: Option<String>) -> Vec<String> {

--- a/cargo-geiger/src/krates_utils.rs
+++ b/cargo-geiger/src/krates_utils.rs
@@ -1,6 +1,8 @@
-use cargo::core::{Package, PackageId, PackageSet};
-use cargo_metadata::Metadata;
+use cargo::core::dependency::DepKind;
+use cargo::core::{Package, PackageId, PackageSet, Resolve};
+use cargo_metadata::{DependencyKind, Metadata};
 use krates::Krates;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 pub struct CargoMetadataParameters<'a> {
@@ -8,9 +10,114 @@ pub struct CargoMetadataParameters<'a> {
     pub metadata: &'a Metadata,
 }
 
+impl DepsNotReplaced for cargo_metadata::Metadata {
+    fn deps_not_replaced(
+        &self,
+        krates: &Krates,
+        package_id: cargo_metadata::PackageId,
+        package_set: &PackageSet,
+        resolve: &Resolve,
+    ) -> Vec<(
+        cargo_metadata::PackageId,
+        HashSet<cargo_metadata::Dependency>,
+    )> {
+        let cargo_core_package_id =
+            package_id.to_package_id(krates, package_set);
+        let deps_not_replaced =
+            resolve.deps_not_replaced(cargo_core_package_id);
+
+        let mut cargo_metadata_deps_not_replaced = vec![];
+
+        for (dep_package_id, _) in deps_not_replaced {
+            cargo_metadata_deps_not_replaced.push((
+                dep_package_id.to_cargo_metadata_package_id(self),
+                HashSet::<cargo_metadata::Dependency>::new(),
+            ))
+        }
+
+        cargo_metadata_deps_not_replaced
+    }
+}
+
+impl GetPackageNameFromCargoMetadataPackageId for Krates {
+    fn get_package_name_from_cargo_metadata_package_id(
+        &self,
+        package_id: &cargo_metadata::PackageId,
+    ) -> String {
+        let package = self.node_for_kid(package_id);
+        package.unwrap().krate.clone().name
+    }
+}
+
+impl GetPackageVersionFromCargoMetadataPackageId for Krates {
+    fn get_package_version_from_cargo_metadata_package_id(
+        &self,
+        package_id: &cargo_metadata::PackageId,
+    ) -> cargo_metadata::Version {
+        let package = self.node_for_kid(package_id);
+        package.unwrap().krate.clone().version
+    }
+}
+
 impl GetRoot for cargo_metadata::Package {
     fn get_root(&self) -> PathBuf {
         self.manifest_path.parent().unwrap().to_path_buf()
+    }
+}
+
+impl MatchesIgnoringSource for cargo_metadata::Dependency {
+    fn matches_ignoring_source(
+        &self,
+        krates: &Krates,
+        package_id: cargo_metadata::PackageId,
+    ) -> bool {
+        self.name
+            == krates
+                .get_package_name_from_cargo_metadata_package_id(&package_id)
+            && self.req.matches(
+                &krates.get_package_version_from_cargo_metadata_package_id(
+                    &package_id,
+                ),
+            )
+    }
+}
+
+impl Replacement for cargo_metadata::PackageId {
+    fn replace(
+        &self,
+        cargo_metadata_parameters: &CargoMetadataParameters,
+        package_set: &PackageSet,
+        resolve: &Resolve,
+    ) -> cargo_metadata::PackageId {
+        let package_id =
+            self.to_package_id(cargo_metadata_parameters.krates, package_set);
+        match resolve.replacement(package_id) {
+            Some(id) => id.to_cargo_metadata_package_id(
+                cargo_metadata_parameters.metadata,
+            ),
+            None => self.clone(),
+        }
+    }
+}
+
+impl ToCargoCoreDepKind for DependencyKind {
+    fn to_cargo_core_dep_kind(&self) -> DepKind {
+        match self {
+            DependencyKind::Build => DepKind::Build,
+            DependencyKind::Development => DepKind::Development,
+            DependencyKind::Normal => DepKind::Normal,
+            _ => panic!("Unknown dependency kind"),
+        }
+    }
+}
+
+impl ToCargoMetadataDependencyKind for DepKind {
+    fn to_cargo_metadata_dependency_kind(&self) -> DependencyKind {
+        match self {
+            DepKind::Build => DependencyKind::Build,
+            DepKind::Development => DependencyKind::Development,
+            DepKind::Normal => DependencyKind::Normal,
+        }
     }
 }
 
@@ -77,8 +184,60 @@ impl ToPackageId for cargo_metadata::PackageId {
     }
 }
 
+pub trait DepsNotReplaced {
+    fn deps_not_replaced(
+        &self,
+        krates: &Krates,
+        package_id: cargo_metadata::PackageId,
+        package_set: &PackageSet,
+        resolve: &Resolve,
+    ) -> Vec<(
+        cargo_metadata::PackageId,
+        HashSet<cargo_metadata::Dependency>,
+    )>;
+}
+
+pub trait GetPackageNameFromCargoMetadataPackageId {
+    fn get_package_name_from_cargo_metadata_package_id(
+        &self,
+        package_id: &cargo_metadata::PackageId,
+    ) -> String;
+}
+
+pub trait GetPackageVersionFromCargoMetadataPackageId {
+    fn get_package_version_from_cargo_metadata_package_id(
+        &self,
+        package_id: &cargo_metadata::PackageId,
+    ) -> cargo_metadata::Version;
+}
+
 pub trait GetRoot {
     fn get_root(&self) -> PathBuf;
+}
+
+pub trait MatchesIgnoringSource {
+    fn matches_ignoring_source(
+        &self,
+        krates: &Krates,
+        package_id: cargo_metadata::PackageId,
+    ) -> bool;
+}
+
+pub trait Replacement {
+    fn replace(
+        &self,
+        cargo_metadata_parameters: &CargoMetadataParameters,
+        package_set: &PackageSet,
+        resolve: &Resolve,
+    ) -> cargo_metadata::PackageId;
+}
+
+pub trait ToCargoCoreDepKind {
+    fn to_cargo_core_dep_kind(&self) -> DepKind;
+}
+
+pub trait ToCargoMetadataDependencyKind {
+    fn to_cargo_metadata_dependency_kind(&self) -> DependencyKind;
 }
 
 pub trait ToCargoMetadataPackage {
@@ -117,13 +276,200 @@ mod krates_utils_tests {
     use std::path::PathBuf;
 
     #[rstest]
+    fn deps_not_replaced_test() {
+        let args = FeaturesArgs::default();
+        let config = Config::default().unwrap();
+        let manifest_path: Option<PathBuf> = None;
+        let workspace = get_workspace(&config, manifest_path).unwrap();
+        let package = workspace.current().unwrap();
+        let mut registry = get_registry(&config, &package).unwrap();
+
+        let (package_set, resolve) =
+            resolve(&args, package.package_id(), &mut registry, &workspace)
+                .unwrap();
+
+        let (krates, metadata) = construct_krates_and_metadata();
+        let cargo_metadata_package_id =
+            package.package_id().to_cargo_metadata_package_id(&metadata);
+
+        let deps_not_replaced = resolve.deps_not_replaced(package.package_id());
+        let cargo_metadata_deps_not_replaced = metadata.deps_not_replaced(
+            &krates,
+            cargo_metadata_package_id,
+            &package_set,
+            &resolve,
+        );
+
+        let mut cargo_core_package_names = deps_not_replaced
+            .map(|(p, _)| p.name().to_string())
+            .collect::<Vec<String>>();
+
+        let mut cargo_metadata_package_names = cargo_metadata_deps_not_replaced
+            .iter()
+            .map(|(p, _)| {
+                krates.get_package_name_from_cargo_metadata_package_id(p)
+            })
+            .collect::<Vec<String>>();
+
+        cargo_core_package_names.sort();
+        cargo_metadata_package_names.sort();
+
+        assert_eq!(cargo_core_package_names, cargo_metadata_package_names);
+    }
+
+    #[rstest]
+    fn get_package_name_from_cargo_metadata_package_id_test() {
+        let (krates, metadata) = construct_krates_and_metadata();
+        let package = metadata.root_package().unwrap();
+        let package_name =
+            krates.get_package_name_from_cargo_metadata_package_id(&package.id);
+        assert_eq!(package_name, package.name);
+    }
+
+    #[rstest]
+    fn get_package_version_from_cargo_metadata_package_id_test() {
+        let (krates, metadata) = construct_krates_and_metadata();
+        let package = metadata.root_package().unwrap();
+        let package_version = krates
+            .get_package_version_from_cargo_metadata_package_id(&package.id);
+        assert_eq!(package_version, package.version);
+    }
+
+    #[rstest]
+    fn get_root_test() {
+        let (_, metadata) = construct_krates_and_metadata();
+        let package = metadata.root_package().unwrap();
+        let package_root = package.get_root();
+        assert_eq!(
+            package_root,
+            package.manifest_path.parent().unwrap().to_path_buf()
+        );
+    }
+
+    #[rstest]
+    fn matches_ignoring_source_test() {
+        let (krates, metadata) = construct_krates_and_metadata();
+        let package = metadata.root_package().unwrap();
+
+        let dependency = package.dependencies.clone().pop().unwrap();
+
+        assert_eq!(
+            dependency.matches_ignoring_source(&krates, package.clone().id),
+            false
+        );
+
+        let dependency_package_id = krates
+            .krates()
+            .filter(|k| {
+                k.krate.name == dependency.name
+                    && dependency.req.matches(&k.krate.version)
+            })
+            .map(|k| k.id.clone())
+            .collect::<Vec<cargo_metadata::PackageId>>()
+            .pop()
+            .unwrap();
+
+        assert!(
+            dependency.matches_ignoring_source(&krates, dependency_package_id),
+            true
+        );
+    }
+
+    #[rstest]
+    fn replace_test() {
+        let args = FeaturesArgs::default();
+        let config = Config::default().unwrap();
+        let manifest_path: Option<PathBuf> = None;
+        let workspace = get_workspace(&config, manifest_path).unwrap();
+        let package = workspace.current().unwrap();
+        let mut registry = get_registry(&config, &package).unwrap();
+
+        let (package_set, resolve) =
+            resolve(&args, package.package_id(), &mut registry, &workspace)
+                .unwrap();
+
+        let (krates, metadata) = construct_krates_and_metadata();
+        let cargo_metadata_package_id =
+            package.package_id().to_cargo_metadata_package_id(&metadata);
+        let cargo_metadata_parameters = CargoMetadataParameters {
+            krates: &krates,
+            metadata: &metadata,
+        };
+
+        assert_eq!(
+            cargo_metadata_package_id,
+            cargo_metadata_package_id.replace(
+                &cargo_metadata_parameters,
+                &package_set,
+                &resolve
+            )
+        )
+    }
+
+    #[rstest(
+        input_dependency_kind,
+        expected_dep_kind,
+        case(DependencyKind::Build, DepKind::Build),
+        case(DependencyKind::Development, DepKind::Development),
+        case(DependencyKind::Normal, DepKind::Normal)
+    )]
+    fn to_cargo_core_dep_kind(
+        input_dependency_kind: DependencyKind,
+        expected_dep_kind: DepKind,
+    ) {
+        assert_eq!(
+            input_dependency_kind.to_cargo_core_dep_kind(),
+            expected_dep_kind
+        )
+    }
+
+    #[rstest(
+        input_dep_kind,
+        expected_dependency_kind,
+        case(DepKind::Build, DependencyKind::Build),
+        case(DepKind::Development, DependencyKind::Development),
+        case(DepKind::Normal, DependencyKind::Normal)
+    )]
+    fn to_cargo_metadata_dependency_kind_test(
+        input_dep_kind: DepKind,
+        expected_dependency_kind: DependencyKind,
+    ) {
+        assert_eq!(
+            input_dep_kind.to_cargo_metadata_dependency_kind(),
+            expected_dependency_kind
+        );
+    }
+
+    #[rstest]
+    fn to_cargo_metadata_package_test() {
+        let config = Config::default().unwrap();
+        let manifest_path: Option<PathBuf> = None;
+        let workspace = get_workspace(&config, manifest_path).unwrap();
+        let package = workspace.current().unwrap();
+
+        let (_, metadata) = construct_krates_and_metadata();
+
+        let cargo_metadata_package =
+            package.to_cargo_metadata_package(&metadata);
+
+        assert_eq!(cargo_metadata_package.name, package.name().to_string());
+        assert!(
+            cargo_metadata_package.version.major == package.version().major
+                && cargo_metadata_package.version.minor
+                    == package.version().minor
+                && cargo_metadata_package.version.patch
+                    == package.version().patch
+        );
+    }
+
+    #[rstest]
     fn to_cargo_metadata_package_id_test() {
         let config = Config::default().unwrap();
         let manifest_path: Option<PathBuf> = None;
         let workspace = get_workspace(&config, manifest_path).unwrap();
         let package = workspace.current().unwrap();
 
-        let metadata = construct_metadata();
+        let (_, metadata) = construct_krates_and_metadata();
         let cargo_metadata_package_id =
             package.package_id().to_cargo_metadata_package_id(&metadata);
 
@@ -143,10 +489,7 @@ mod krates_utils_tests {
             resolve(&args, package.package_id(), &mut registry, &workspace)
                 .unwrap();
 
-        let metadata = construct_metadata();
-        let krates = Builder::new()
-            .build_with_metadata(metadata.clone(), |_| ())
-            .unwrap();
+        let (krates, metadata) = construct_krates_and_metadata();
 
         let cargo_metadata_package = metadata.root_package().unwrap();
         let package_id = cargo_metadata_package
@@ -157,11 +500,17 @@ mod krates_utils_tests {
         assert_eq!(cargo_metadata_package.name, package_id.name().to_string());
     }
 
-    fn construct_metadata() -> Metadata {
-        MetadataCommand::new()
+    fn construct_krates_and_metadata() -> (Krates, Metadata) {
+        let metadata = MetadataCommand::new()
             .manifest_path("./Cargo.toml")
             .features(CargoOpt::AllFeatures)
             .exec()
-            .unwrap()
+            .unwrap();
+
+        let krates = Builder::new()
+            .build_with_metadata(metadata.clone(), |_| ())
+            .unwrap();
+
+        (krates, metadata)
     }
 }

--- a/cargo-geiger/src/scan/default.rs
+++ b/cargo-geiger/src/scan/default.rs
@@ -131,9 +131,13 @@ fn scan_to_report(
         workspace,
     )?;
     let mut report = SafetyReport::default();
-    for (package, package_metrics_option) in
-        package_metrics(&geiger_context, graph, root_package_id)
-    {
+    for (package, package_metrics_option) in package_metrics(
+        cargo_metadata_parameters,
+        &geiger_context,
+        graph,
+        package_set,
+        root_package_id,
+    ) {
         let package_metrics = match package_metrics_option {
             Some(m) => m,
             None => {
@@ -141,7 +145,7 @@ fn scan_to_report(
                 continue;
             }
         };
-        let unsafe_info = unsafe_stats(package_metrics, &rs_files_used);
+        let unsafe_info = unsafe_stats(&package_metrics, &rs_files_used);
         let entry = ReportEntry {
             package,
             unsafety: unsafe_info,

--- a/cargo-geiger/src/scan/forbid.rs
+++ b/cargo-geiger/src/scan/forbid.rs
@@ -58,9 +58,13 @@ fn scan_forbid_to_report(
         print_config,
     )?;
     let mut report = QuickSafetyReport::default();
-    for (package, package_metrics) in
-        package_metrics(&geiger_context, graph, root_package_id)
-    {
+    for (package, package_metrics) in package_metrics(
+        cargo_metadata_parameters,
+        &geiger_context,
+        graph,
+        package_set,
+        root_package_id,
+    ) {
         let pack_metrics = match package_metrics {
             Some(m) => m,
             None => {


### PR DESCRIPTION
* Pull further structs from `Args` struct
* Add functions to krates_utils for `replace` and `deps_not_replaced`
  functions from resolve
* Add function for `matches_ignoring_source`
* Adding functions to extract the name and version of a cargo_metadata
  package from the `PackageId`
* Remove usage of cargo core from `graph` module

Signed-off-by: joshmc <josh-mcc@tiscali.co.uk>