### PR TITLE
ISSUE-16 - Remove usage of `ManifestMetadata`:

### DIFF
--- a/cargo-geiger/src/format/pattern.rs
+++ b/cargo-geiger/src/format/pattern.rs
@@ -4,7 +4,6 @@ use crate::format::{Chunk, RawChunk};
 use super::display::Display;
 
 use crate::mapping::CargoMetadataParameters;
-use cargo::core::manifest::ManifestMetadata;
 use std::error::Error;
 
 #[derive(Debug, PartialEq)]
@@ -14,14 +13,12 @@ impl Pattern {
     pub fn display<'a>(
         &'a self,
         cargo_metadata_parameters: &'a CargoMetadataParameters,
-        metadata: &'a ManifestMetadata,
         package: &'a cargo_metadata::PackageId,
     ) -> Display<'a> {
         Display {
             cargo_metadata_parameters,
             pattern: self,
             package,
-            metadata,
         }
     }
 

--- a/cargo-geiger/src/format/table.rs
+++ b/cargo-geiger/src/format/table.rs
@@ -4,6 +4,7 @@ mod total_package_counts;
 use crate::format::emoji_symbols::EmojiSymbols;
 use crate::format::print_config::{colorize, PrintConfig};
 use crate::format::CrateDetectionStatus;
+use crate::mapping::CargoMetadataParameters;
 use crate::scan::GeigerContext;
 use crate::tree::TextTreeLine;
 
@@ -13,8 +14,6 @@ use handle_text_tree_line::{
 };
 use total_package_counts::TotalPackageCounts;
 
-use crate::mapping::CargoMetadataParameters;
-use cargo::core::package::PackageSet;
 use cargo_geiger_serde::{Count, CounterBlock};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -33,7 +32,6 @@ pub const UNSAFE_COUNTERS_HEADER: [&str; 6] = [
 
 pub fn create_table_from_text_tree_lines(
     cargo_metadata_parameters: &CargoMetadataParameters,
-    package_set: &PackageSet,
     table_parameters: &TableParameters,
     text_tree_lines: Vec<TextTreeLine>,
 ) -> (Vec<String>, u64) {
@@ -67,7 +65,6 @@ pub fn create_table_from_text_tree_lines(
                 &emoji_symbols,
                 &mut handle_package_parameters,
                 package_id,
-                package_set,
                 &mut table_lines,
                 table_parameters,
                 tree_vines,

--- a/cargo-geiger/src/format/table/handle_text_tree_line.rs
+++ b/cargo-geiger/src/format/table/handle_text_tree_line.rs
@@ -1,7 +1,7 @@
 use crate::format::emoji_symbols::EmojiSymbols;
 use crate::format::print_config::colorize;
 use crate::format::{get_kind_group_name, CrateDetectionStatus, SymbolKind};
-use crate::mapping::{CargoMetadataParameters, ToPackage};
+use crate::mapping::CargoMetadataParameters;
 use crate::scan::unsafe_stats;
 
 use super::total_package_counts::TotalPackageCounts;
@@ -9,7 +9,6 @@ use super::TableParameters;
 use super::{table_row, table_row_empty};
 
 use cargo::core::dependency::DepKind;
-use cargo::core::package::PackageSet;
 use std::collections::HashSet;
 
 pub struct HandlePackageParameters<'a> {
@@ -33,13 +32,11 @@ pub fn handle_text_tree_line_extra_deps_group(
     table_lines.push(format!("{}{}{}", table_row_empty(), tree_vines, name));
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn handle_text_tree_line_package(
     cargo_metadata_parameters: &CargoMetadataParameters,
     emoji_symbols: &EmojiSymbols,
     handle_package_parameters: &mut HandlePackageParameters,
     package_id: cargo_metadata::PackageId,
-    package_set: &PackageSet,
     table_lines: &mut Vec<String>,
     table_parameters: &TableParameters,
     tree_vines: String,
@@ -47,9 +44,6 @@ pub fn handle_text_tree_line_package(
     let package_is_new = handle_package_parameters
         .visited_package_ids
         .insert(package_id.clone());
-
-    let package =
-        package_id.to_package(cargo_metadata_parameters.krates, package_set);
 
     let package_metrics = match table_parameters
         .geiger_context
@@ -99,11 +93,10 @@ pub fn handle_text_tree_line_package(
     let package_name = colorize(
         format!(
             "{}",
-            table_parameters.print_config.format.display(
-                cargo_metadata_parameters,
-                package.manifest().metadata(),
-                &package_id
-            )
+            table_parameters
+                .print_config
+                .format
+                .display(cargo_metadata_parameters, &package_id)
         ),
         &crate_detection_status,
     );

--- a/cargo-geiger/src/mapping.rs
+++ b/cargo-geiger/src/mapping.rs
@@ -4,7 +4,6 @@ mod metadata;
 
 use ::krates::Krates;
 use cargo::core::dependency::DepKind;
-use cargo::core::manifest::ManifestMetadata;
 use cargo::core::{Package, PackageId, PackageSet, Resolve};
 use cargo_metadata::{DependencyKind, Metadata};
 use std::collections::HashSet;
@@ -28,12 +27,11 @@ pub trait DepsNotReplaced {
     )>;
 }
 
-pub trait GetManifestMetadataFromCargoMetadataPackageId {
-    fn get_manifest_metadata_from_cargo_metadata_package_id(
+pub trait GetLicenceFromCargoMetadataPackageId {
+    fn get_licence_from_cargo_metadata_package_id(
         &self,
         package_id: &cargo_metadata::PackageId,
-        package_set: &PackageSet,
-    ) -> ManifestMetadata;
+    ) -> Option<String>;
 }
 
 pub trait GetPackageNameFromCargoMetadataPackageId {
@@ -48,6 +46,13 @@ pub trait GetPackageVersionFromCargoMetadataPackageId {
         &self,
         package_id: &cargo_metadata::PackageId,
     ) -> cargo_metadata::Version;
+}
+
+pub trait GetRepositoryFromCargoMetadataPackageId {
+    fn get_repository_from_cargo_metadata_package_id(
+        &self,
+        package_id: &cargo_metadata::PackageId,
+    ) -> Option<String>;
 }
 
 pub trait GetRoot {

--- a/cargo-geiger/src/scan/default/table.rs
+++ b/cargo-geiger/src/scan/default/table.rs
@@ -66,7 +66,6 @@ pub fn scan_to_table(
     let (mut table_lines, mut warning_count) =
         create_table_from_text_tree_lines(
             cargo_metadata_parameters,
-            package_set,
             &table_parameters,
             text_tree_lines,
         );

--- a/cargo-geiger/src/scan/forbid/table.rs
+++ b/cargo-geiger/src/scan/forbid/table.rs
@@ -3,9 +3,7 @@ use crate::format::pattern::Pattern;
 use crate::format::print_config::PrintConfig;
 use crate::format::{get_kind_group_name, SymbolKind};
 use crate::graph::Graph;
-use crate::mapping::{
-    CargoMetadataParameters, GetManifestMetadataFromCargoMetadataPackageId,
-};
+use crate::mapping::CargoMetadataParameters;
 use crate::tree::traversal::walk_dependency_tree;
 use crate::tree::TextTreeLine;
 
@@ -67,7 +65,6 @@ pub fn scan_forbid_to_table(
                     &emoji_symbols,
                     &geiger_ctx,
                     package_id,
-                    package_set,
                     print_config,
                     &mut scan_output_lines,
                     tree_vines,
@@ -112,31 +109,19 @@ fn construct_key_lines(emoji_symbols: &EmojiSymbols) -> Vec<String> {
 fn format_package_name(
     cargo_metadata_parameters: &CargoMetadataParameters,
     package_id: &cargo_metadata::PackageId,
-    package_set: &PackageSet,
     pattern: &Pattern,
 ) -> String {
     format!(
         "{}",
-        pattern.display(
-            cargo_metadata_parameters,
-            &cargo_metadata_parameters
-                .krates
-                .get_manifest_metadata_from_cargo_metadata_package_id(
-                    package_id,
-                    package_set
-                ),
-            &package_id
-        )
+        pattern.display(cargo_metadata_parameters, &package_id)
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn handle_package_text_tree_line(
     cargo_metadata_parameters: &CargoMetadataParameters,
     emoji_symbols: &EmojiSymbols,
     geiger_ctx: &GeigerContext,
     package_id: cargo_metadata::PackageId,
-    package_set: &PackageSet,
     print_config: &PrintConfig,
     scan_output_lines: &mut Vec<String>,
     tree_vines: String,
@@ -147,7 +132,6 @@ fn handle_package_text_tree_line(
     let name = format_package_name(
         cargo_metadata_parameters,
         &package_id,
-        package_set,
         &print_config.format,
     );
     let package_metrics = geiger_ctx.package_id_to_metrics.get(&package_id);


### PR DESCRIPTION
* Add functions to extract licence and repository from
  `cargo_metadata::PackageId`
* Remove `ManifestMetadata` from display
* Add testing