### PR TITLE
ISSUE-149 - Clarify install section for macOS users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Try to find and use a system-wide installed OpenSSL library:
 cargo install cargo-geiger
 ```
 
-Or, build and statically link OpenSSL as part of the cargo-geiger executable:
+Or, use OpenSSL from the
+[openssl-sys crate](https://docs.rs/openssl/0.10.30/openssl/).
+This works on macOS.  Run:
 ```
 cargo install cargo-geiger --features vendored-openssl
 ```


### PR DESCRIPTION
This PR was [requested](https://github.com/rust-secure-code/cargo-geiger/issues/149#issuecomment-735421330) by @anderejd :

> > Update the readme to state that vendored-openssl feature uses "OpenSSL from the openssl-sys crate" and builds on macOS.
> 
> A PR with README.md improvements would be most welcome.
