### PR TITLE
ISSUE-151 - Fix a bug where a report wasn't written if any warning

### DIFF
--- a/cargo-geiger/src/format/table.rs
+++ b/cargo-geiger/src/format/table.rs
@@ -5,7 +5,7 @@ use crate::format::emoji_symbols::EmojiSymbols;
 use crate::format::print_config::{colorize, PrintConfig};
 use crate::format::CrateDetectionStatus;
 use crate::mapping::CargoMetadataParameters;
-use crate::scan::GeigerContext;
+use crate::scan::{GeigerContext, ScanResult};
 use crate::tree::TextTreeLine;
 
 use handle_text_tree_line::{
@@ -34,7 +34,7 @@ pub fn create_table_from_text_tree_lines(
     cargo_metadata_parameters: &CargoMetadataParameters,
     table_parameters: &TableParameters,
     text_tree_lines: Vec<TextTreeLine>,
-) -> (Vec<String>, u64) {
+) -> ScanResult {
     let mut table_lines = Vec::<String>::new();
     let mut total_package_counts = TotalPackageCounts::new();
     let mut warning_count = 0;
@@ -87,7 +87,10 @@ pub fn create_table_from_text_tree_lines(
 
     table_lines.push(String::new());
 
-    (table_lines, warning_count)
+    ScanResult {
+        scan_output_lines: table_lines,
+        warning_count,
+    }
 }
 
 pub struct TableParameters<'a> {

--- a/cargo-geiger/src/main.rs
+++ b/cargo-geiger/src/main.rs
@@ -19,7 +19,7 @@ use cargo_geiger::mapping::{CargoMetadataParameters, QueryResolve};
 use cargo_geiger::readme::{
     create_or_replace_section_in_readme, README_FILENAME,
 };
-use cargo_geiger::scan::scan;
+use cargo_geiger::scan::{scan, FoundWarningsError, ScanResult};
 
 use cargo::core::shell::Shell;
 use cargo::util::important_paths;
@@ -82,7 +82,10 @@ fn real_main(args: &Args, config: &mut Config) -> CliResult {
         },
     );
 
-    let scan_output_lines = scan(
+    let ScanResult {
+        scan_output_lines,
+        warning_count,
+    } = scan(
         args,
         &cargo_metadata_parameters,
         config,
@@ -103,6 +106,13 @@ fn real_main(args: &Args, config: &mut Config) -> CliResult {
         for scan_output_line in scan_output_lines {
             println!("{}", scan_output_line);
         }
+    }
+
+    if warning_count > 0 {
+        return Err(CliError::new(
+            anyhow::Error::new(FoundWarningsError { warning_count }),
+            1,
+        ));
     }
 
     Ok(())

--- a/cargo-geiger/src/scan/default.rs
+++ b/cargo-geiger/src/scan/default.rs
@@ -9,7 +9,7 @@ use crate::scan::rs_file::resolve_rs_file_deps;
 use super::find::find_unsafe;
 use super::{
     list_files_used_but_not_scanned, package_metrics, unsafe_stats,
-    ScanDetails, ScanMode, ScanParameters,
+    ScanDetails, ScanMode, ScanParameters, ScanResult,
 };
 
 use table::scan_to_table;
@@ -27,7 +27,7 @@ pub fn scan_unsafe(
     root_package_id: PackageId,
     scan_parameters: &ScanParameters,
     workspace: &Workspace,
-) -> Result<Vec<String>, CliError> {
+) -> Result<ScanResult, CliError> {
     match scan_parameters.args.output_format {
         Some(output_format) => scan_to_report(
             cargo_metadata_parameters,
@@ -115,7 +115,7 @@ fn scan_to_report(
     root_package_id: PackageId,
     scan_parameters: &ScanParameters,
     workspace: &Workspace,
-) -> Result<Vec<String>, CliError> {
+) -> Result<ScanResult, CliError> {
     let ScanDetails {
         rs_files_used,
         geiger_context,
@@ -148,7 +148,11 @@ fn scan_to_report(
     let s = match output_format {
         OutputFormat::Json => serde_json::to_string(&report).unwrap(),
     };
-    Ok(vec![s])
+
+    Ok(ScanResult {
+        scan_output_lines: vec![s],
+        warning_count: 0,
+    })
 }
 
 #[cfg(test)]

--- a/cargo-geiger/src/scan/forbid.rs
+++ b/cargo-geiger/src/scan/forbid.rs
@@ -5,7 +5,7 @@ use crate::graph::Graph;
 use crate::mapping::CargoMetadataParameters;
 
 use super::find::find_unsafe;
-use super::{package_metrics, ScanMode, ScanParameters};
+use super::{package_metrics, ScanMode, ScanParameters, ScanResult};
 
 use table::scan_forbid_to_table;
 
@@ -18,7 +18,7 @@ pub fn scan_forbid_unsafe(
     graph: &Graph,
     root_package_id: PackageId,
     scan_parameters: &ScanParameters,
-) -> Result<Vec<String>, CliError> {
+) -> Result<ScanResult, CliError> {
     match scan_parameters.args.output_format {
         Some(output_format) => scan_forbid_to_report(
             cargo_metadata_parameters,
@@ -45,7 +45,7 @@ fn scan_forbid_to_report(
     output_format: OutputFormat,
     print_config: &PrintConfig,
     root_package_id: PackageId,
-) -> Result<Vec<String>, CliError> {
+) -> Result<ScanResult, CliError> {
     let geiger_context = find_unsafe(
         cargo_metadata_parameters,
         config,
@@ -81,5 +81,8 @@ fn scan_forbid_to_report(
         OutputFormat::Json => serde_json::to_string(&report).unwrap(),
     };
 
-    Ok(vec![s])
+    Ok(ScanResult {
+        scan_output_lines: vec![s],
+        warning_count: 0,
+    })
 }

--- a/cargo-geiger/src/scan/forbid/table.rs
+++ b/cargo-geiger/src/scan/forbid/table.rs
@@ -9,7 +9,7 @@ use crate::tree::traversal::walk_dependency_tree;
 use crate::tree::TextTreeLine;
 
 use super::super::find::find_unsafe;
-use super::super::ScanMode;
+use super::super::{ScanMode, ScanResult};
 
 use cargo::{CliError, Config};
 use cargo_metadata::PackageId;
@@ -21,7 +21,7 @@ pub fn scan_forbid_to_table(
     graph: &Graph,
     print_config: &PrintConfig,
     root_package_id: PackageId,
-) -> Result<Vec<String>, CliError> {
+) -> Result<ScanResult, CliError> {
     let mut scan_output_lines = Vec::<String>::new();
     let emoji_symbols = EmojiSymbols::new(print_config.charset);
 
@@ -70,7 +70,10 @@ pub fn scan_forbid_to_table(
         }
     }
 
-    Ok(scan_output_lines)
+    Ok(ScanResult {
+        scan_output_lines,
+        warning_count: 0,
+    })
 }
 
 fn construct_key_lines(emoji_symbols: &EmojiSymbols) -> Vec<String> {


### PR DESCRIPTION
was found:
* When updating the scanning functions to return results as a vec of
  strings, a bug was introduced where the report would only be written
  if no warnings were returned

Signed-off-by: joshmc <josh-mcc@tiscali.co.uk>