### PR TITLE
Add new Ratio output type --output-format=Ratio

### DIFF
--- a/cargo-geiger/src/args.rs
+++ b/cargo-geiger/src/args.rs
@@ -31,7 +31,7 @@ OPTIONS:
     --format <FORMAT>             Format string used for printing dependencies
                                   [default: {p}].
     --output-format               Output format for the report: Ascii, GitHubMarkdown,
-                                  Json, Utf8 [default: Utf8]
+                                  Json, Utf8, Ratio [default: Utf8]
     --update-readme               Writes output to ./README.md. Looks for a Safety
                                   Report section, replaces if found, adds if not.
                                   Throws an error if no README.md exists.

--- a/cargo-geiger/src/format/print_config.rs
+++ b/cargo-geiger/src/format/print_config.rs
@@ -21,8 +21,8 @@ pub enum OutputFormat {
     Ascii,
     Json,
     GitHubMarkdown,
-    Utf8,
     Ratio,
+    Utf8,
 }
 
 impl Default for OutputFormat {

--- a/cargo-geiger/src/format/print_config.rs
+++ b/cargo-geiger/src/format/print_config.rs
@@ -22,6 +22,7 @@ pub enum OutputFormat {
     Json,
     GitHubMarkdown,
     Utf8,
+    Ratio,
 }
 
 impl Default for OutputFormat {

--- a/cargo-geiger/src/format/table.rs
+++ b/cargo-geiger/src/format/table.rs
@@ -317,14 +317,15 @@ mod table_tests {
         .collect();
         let unsafety = unsafe_stats(&package_metrics, &rs_files_used);
 
-        let table_row = table_row(&unsafety.used, &unsafety.unused);
+        let table_row =
+            table_row(&unsafety.used, &unsafety.unused, OutputFormat::Ascii);
         assert_eq!(table_row, "4/6        8/12         12/18  16/24   20/30  ");
     }
 
     #[rstest]
     fn table_row_empty_test() {
         let empty_table_row = table_row_empty();
-        assert_eq!(empty_table_row.len(), 51);
+        assert_eq!(empty_table_row.len(), 55);
     }
 
     #[rstest(

--- a/cargo-geiger/src/format/table.rs
+++ b/cargo-geiger/src/format/table.rs
@@ -107,71 +107,117 @@ fn table_footer(
     output_format: OutputFormat,
     status: CrateDetectionStatus,
 ) -> ColoredString {
-    match output_format { 
-        OutputFormat::Ratio => { // print safe ratio 
-                let fmt = |used: &Count, not_used: &Count| {
-                    format!("{:>5}/{:<}={:.2}%", (used.safe + not_used.safe), (used.safe + used.unsafe_ + not_used.unsafe_ + not_used.safe), 
-                            if used.safe + used.unsafe_ + not_used.unsafe_ + not_used.safe == 0 { 100.0 } 
-                            else {(100.00*(used.safe + not_used.safe) as f32)/((used.safe + used.unsafe_ + not_used.unsafe_ + not_used.safe) as f32)}
-                    )
-                };
-                let output = format!(
-                    "{: <12} {: <18} {: <18} {: <12} {: <12}",
-                    fmt(&used.functions, &not_used.functions),
-                    fmt(&used.exprs, &not_used.exprs),
-                    fmt(&used.item_impls, &not_used.item_impls),
-                    fmt(&used.item_traits, &not_used.item_traits),
-                    fmt(&used.methods, &not_used.methods),
-                );
-                colorize(&status, output_format, output)
+    match output_format {
+        OutputFormat::Ratio => {
+            // print safe ratio
+            let fmt = |used: &Count, not_used: &Count| {
+                format!(
+                    "{:>5}/{:<}={:.2}%",
+                    (used.safe + not_used.safe),
+                    (used.safe
+                        + used.unsafe_
+                        + not_used.unsafe_
+                        + not_used.safe),
+                    if used.safe
+                        + used.unsafe_
+                        + not_used.unsafe_
+                        + not_used.safe
+                        == 0
+                    {
+                        100.0
+                    } else {
+                        (100.00 * (used.safe + not_used.safe) as f32)
+                            / ((used.safe
+                                + used.unsafe_
+                                + not_used.unsafe_
+                                + not_used.safe)
+                                as f32)
+                    }
+                )
+            };
+            let output = format!(
+                "{: <12} {: <18} {: <18} {: <12} {: <12}",
+                fmt(&used.functions, &not_used.functions),
+                fmt(&used.exprs, &not_used.exprs),
+                fmt(&used.item_impls, &not_used.item_impls),
+                fmt(&used.item_traits, &not_used.item_traits),
+                fmt(&used.methods, &not_used.methods),
+            );
+            colorize(&status, output_format, output)
         }
         _ => {
-                let fmt = |used: &Count, not_used: &Count| {
-                    format!("{}/{}", used.unsafe_, used.unsafe_ + not_used.unsafe_)
-                };
-                let output = format!(
-                    "{: <10} {: <12} {: <6} {: <7} {: <7}",
-                    fmt(&used.functions, &not_used.functions),
-                    fmt(&used.exprs, &not_used.exprs),
-                    fmt(&used.item_impls, &not_used.item_impls),
-                    fmt(&used.item_traits, &not_used.item_traits),
-                    fmt(&used.methods, &not_used.methods),
-                );
-                colorize(&status, output_format, output)
+            let fmt = |used: &Count, not_used: &Count| {
+                format!("{}/{}", used.unsafe_, used.unsafe_ + not_used.unsafe_)
+            };
+            let output = format!(
+                "{: <10} {: <12} {: <6} {: <7} {: <7}",
+                fmt(&used.functions, &not_used.functions),
+                fmt(&used.exprs, &not_used.exprs),
+                fmt(&used.item_impls, &not_used.item_impls),
+                fmt(&used.item_traits, &not_used.item_traits),
+                fmt(&used.methods, &not_used.methods),
+            );
+            colorize(&status, output_format, output)
         }
     }
 }
 
-fn table_row(used: &CounterBlock, not_used: &CounterBlock, output_format: OutputFormat) -> String {
-        match output_format {
-            OutputFormat::Ratio => { // print safe ratio 
-                let fmt = |used: &Count, not_used: &Count| {
-                    format!("{:>5}/{:<}={:.2}%", (used.safe + not_used.safe), (used.safe + used.unsafe_ + not_used.unsafe_ + not_used.safe), 
-                            if used.safe + used.unsafe_ + not_used.unsafe_ + not_used.safe == 0 { 100.0 } 
-                            else {(100.00*(used.safe + not_used.safe) as f32)/((used.safe + used.unsafe_ + not_used.unsafe_ + not_used.safe) as f32)}
-                    )
-                }; 
-                format!("{: <12} {: <18} {: <18} {: <12} {: <12}",
-                        fmt(&used.functions, &not_used.functions),
-                        fmt(&used.exprs, &not_used.exprs),
-                        fmt(&used.item_impls, &not_used.item_impls),
-                        fmt(&used.item_traits, &not_used.item_traits),
-                        fmt(&used.methods, &not_used.methods)
+fn table_row(
+    used: &CounterBlock,
+    not_used: &CounterBlock,
+    output_format: OutputFormat,
+) -> String {
+    match output_format {
+        OutputFormat::Ratio => {
+            // print safe ratio
+            let fmt = |used: &Count, not_used: &Count| {
+                format!(
+                    "{:>5}/{:<}={:.2}%",
+                    (used.safe + not_used.safe),
+                    (used.safe
+                        + used.unsafe_
+                        + not_used.unsafe_
+                        + not_used.safe),
+                    if used.safe
+                        + used.unsafe_
+                        + not_used.unsafe_
+                        + not_used.safe
+                        == 0
+                    {
+                        100.0
+                    } else {
+                        (100.00 * (used.safe + not_used.safe) as f32)
+                            / ((used.safe
+                                + used.unsafe_
+                                + not_used.unsafe_
+                                + not_used.safe)
+                                as f32)
+                    }
                 )
-            }
-            _ => {
-                let fmt = |used: &Count, not_used: &Count| {
-                    format!("{}/{}", used.unsafe_, used.unsafe_ + not_used.unsafe_)
-                };
-                format!("{: <10} {: <12} {: <6} {: <7} {: <7}",
-                        fmt(&used.functions, &not_used.functions),
-                        fmt(&used.exprs, &not_used.exprs),
-                        fmt(&used.item_impls, &not_used.item_impls),
-                        fmt(&used.item_traits, &not_used.item_traits),
-                        fmt(&used.methods, &not_used.methods)
-                )
-            }
+            };
+            format!(
+                "{: <12} {: <18} {: <18} {: <12} {: <12}",
+                fmt(&used.functions, &not_used.functions),
+                fmt(&used.exprs, &not_used.exprs),
+                fmt(&used.item_impls, &not_used.item_impls),
+                fmt(&used.item_traits, &not_used.item_traits),
+                fmt(&used.methods, &not_used.methods)
+            )
         }
+        _ => {
+            let fmt = |used: &Count, not_used: &Count| {
+                format!("{}/{}", used.unsafe_, used.unsafe_ + not_used.unsafe_)
+            };
+            format!(
+                "{: <10} {: <12} {: <6} {: <7} {: <7}",
+                fmt(&used.functions, &not_used.functions),
+                fmt(&used.exprs, &not_used.exprs),
+                fmt(&used.item_impls, &not_used.item_impls),
+                fmt(&used.item_traits, &not_used.item_traits),
+                fmt(&used.methods, &not_used.methods)
+            )
+        }
+    }
 }
 
 fn table_row_empty() -> String {

--- a/cargo-geiger/src/format/table/handle_text_tree_line.rs
+++ b/cargo-geiger/src/format/table/handle_text_tree_line.rs
@@ -104,7 +104,7 @@ pub fn handle_text_tree_line_package(
     let unsafe_info = colorize(
         &crate_detection_status,
         table_parameters.print_config.output_format,
-        table_row(&unsafe_info.used, &unsafe_info.unused),
+        table_row(&unsafe_info.used, &unsafe_info.unused, table_parameters.print_config.output_format),
     );
 
     let shift_chars = unsafe_info.chars().count() + 4;

--- a/cargo-geiger/src/format/table/handle_text_tree_line.rs
+++ b/cargo-geiger/src/format/table/handle_text_tree_line.rs
@@ -104,7 +104,11 @@ pub fn handle_text_tree_line_package(
     let unsafe_info = colorize(
         &crate_detection_status,
         table_parameters.print_config.output_format,
-        table_row(&unsafe_info.used, &unsafe_info.unused, table_parameters.print_config.output_format),
+        table_row(
+            &unsafe_info.used,
+            &unsafe_info.unused,
+            table_parameters.print_config.output_format,
+        ),
     );
 
     let shift_chars = unsafe_info.chars().count() + 4;

--- a/cargo-geiger/src/scan/default/table.rs
+++ b/cargo-geiger/src/scan/default/table.rs
@@ -93,11 +93,19 @@ fn construct_key_lines(
     let mut output_key_lines = Vec::<String>::new();
 
     output_key_lines.push(String::new());
-    output_key_lines.push(String::from("Metric output format: x/y"));
-    output_key_lines
-        .push(String::from("    x = unsafe code used by the build"));
-    output_key_lines
-        .push(String::from("    y = total unsafe code found in the crate"));
+    match output_format {
+        OutputFormat::Ratio => { // Change the prompt for Safe Ratio report:
+            output_key_lines.push(String::from("Metric output format: x/y=z%"));
+            output_key_lines.push(String::from("    x = safe code found in the crate"));
+            output_key_lines.push(String::from("    y = total code found in the crate"));
+            output_key_lines.push(String::from("    z = percentage of safe ratio as defined by x/y"));
+        }
+        _ => {
+            output_key_lines.push(String::from("Metric output format: x/y"));
+            output_key_lines.push(String::from("    x = unsafe code used by the build"));
+            output_key_lines.push(String::from("    y = total unsafe code found in the crate"));
+        }
+    }
     output_key_lines.push(String::new());
     output_key_lines.push(String::from("Symbols: "));
 

--- a/cargo-geiger/src/scan/default/table.rs
+++ b/cargo-geiger/src/scan/default/table.rs
@@ -94,16 +94,24 @@ fn construct_key_lines(
 
     output_key_lines.push(String::new());
     match output_format {
-        OutputFormat::Ratio => { // Change the prompt for Safe Ratio report:
+        OutputFormat::Ratio => {
+            // Change the prompt for Safe Ratio report:
             output_key_lines.push(String::from("Metric output format: x/y=z%"));
-            output_key_lines.push(String::from("    x = safe code found in the crate"));
-            output_key_lines.push(String::from("    y = total code found in the crate"));
-            output_key_lines.push(String::from("    z = percentage of safe ratio as defined by x/y"));
+            output_key_lines
+                .push(String::from("    x = safe code found in the crate"));
+            output_key_lines
+                .push(String::from("    y = total code found in the crate"));
+            output_key_lines.push(String::from(
+                "    z = percentage of safe ratio as defined by x/y",
+            ));
         }
         _ => {
             output_key_lines.push(String::from("Metric output format: x/y"));
-            output_key_lines.push(String::from("    x = unsafe code used by the build"));
-            output_key_lines.push(String::from("    y = total unsafe code found in the crate"));
+            output_key_lines
+                .push(String::from("    x = unsafe code used by the build"));
+            output_key_lines.push(String::from(
+                "    y = total unsafe code found in the crate",
+            ));
         }
     }
     output_key_lines.push(String::new());


### PR DESCRIPTION
I work on Huawei's Trusted Programming project, which was recently asked to report for Rust projects the "safe ratios", i.e. percentages of items that are safe. This could be done using `cargo-geiger`; however, currently it counts unsafe items, rather than reports the safety ratios,

I've completed a working prototype for this by adding `--output-format=Ratio` as an option to the command. If someone with more experience developing in `cargo-geiger` can give this an early look and send feedback, that would be really helpful.

Apologies in advance for the current lack of tests and limited documentation. I'll be working on this full time for a while, so it will improve rapidly.

Thanks!