### PR TITLE
Fixing an error when the crate's name mismatches it will panic

### DIFF
--- a/cargo-geiger/src/mapping/geiger.rs
+++ b/cargo-geiger/src/mapping/geiger.rs
@@ -50,9 +50,7 @@ fn handle_source_repr(source_repr: &str) -> cargo_geiger_serde::Source {
                 rev: String::from(revision),
             }
         }
-        _ => {
-            panic!("Unrecognised source type: {}", source_type)
-        }
+        _ => panic!("Unrecognised source type: {}", source_type),
     }
 }
 

--- a/cargo-geiger/src/mapping/metadata.rs
+++ b/cargo-geiger/src/mapping/metadata.rs
@@ -59,7 +59,8 @@ impl MatchesIgnoringSource for cargo_metadata::Dependency {
         self.name
             == krates
                 .get_package_name_from_cargo_metadata_package_id(&package_id)
-                .unwrap()
+                .unwrap_or(package_id.to_string())
+                //.unwrap()
             && self.req.matches(
                 &krates
                     .get_package_version_from_cargo_metadata_package_id(


### PR DESCRIPTION
This bug fix comes from Huawei's application of `cargo-geiger` to an internal product. After the fix, the tool can run to the end and produce the Safe Ratio report now.
