### PR TITLE
NOISSUE - Update lint enforcement level based on issue

### DIFF
--- a/cargo-geiger-serde/src/lib.rs
+++ b/cargo-geiger-serde/src/lib.rs
@@ -4,7 +4,7 @@
 //! This crate provides definitions to serialize the unsafety report.
 
 #![forbid(unsafe_code)]
-#![forbid(warnings)]
+#![deny(warnings)]
 
 mod package_id;
 mod report;

--- a/cargo-geiger/src/lib.rs
+++ b/cargo-geiger/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(clippy::cargo)]
 #![deny(clippy::doc_markdown)]
 #![forbid(unsafe_code)]
-#![forbid(warnings)]
+#![deny(warnings)]
 
 /// Argument parsing
 pub mod args;

--- a/cargo-geiger/src/main.rs
+++ b/cargo-geiger/src/main.rs
@@ -4,7 +4,7 @@
 #![deny(clippy::cargo)]
 #![deny(clippy::doc_markdown)]
 #![forbid(unsafe_code)]
-#![forbid(warnings)]
+#![deny(warnings)]
 
 extern crate cargo;
 extern crate colored;

--- a/geiger/src/lib.rs
+++ b/geiger/src/lib.rs
@@ -5,7 +5,7 @@
 //! from `cargo`.
 
 #![forbid(unsafe_code)]
-#![forbid(warnings)]
+#![deny(warnings)]
 
 pub mod find;
 mod geiger_syn_visitor;


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/81670 to fix compile warnings
with stable 1.50.0