### PR TITLE
use ExampleBin by default for example target

### DIFF
--- a/cargo-geiger/src/scan/rs_file.rs
+++ b/cargo-geiger/src/scan/rs_file.rs
@@ -117,6 +117,7 @@ pub fn into_target_kind(raw_target_kind: Vec<String>) -> TargetKind {
     match &raw_target_kind_str[..] {
         ["bench"] => TargetKind::Bench,
         ["bin"] => TargetKind::Bin,
+        ["example"] => TargetKind::ExampleBin,
         ["bin", "example"] => TargetKind::ExampleBin,
         ["example", "lib"] => TargetKind::ExampleLib(vec![]),
         ["lib"] => TargetKind::Lib(vec![]),


### PR DESCRIPTION
This fixes a a part of test failure in #193 - at the moment `cargo-geiger` sets `CustomBuildRoot` for code files in `examples` and as a result `itertools/examples/iris.rs` also is assumed to be a custom build root.