### PR TITLE
ISSUE-195 - Fix `Args::parse_args` for `-p` option

### DIFF
--- a/cargo-geiger/src/args.rs
+++ b/cargo-geiger/src/args.rs
@@ -127,7 +127,7 @@ impl Args {
             manifest_path: raw_args.opt_value_from_str("--manifest-path")?,
             no_indent: raw_args.contains("--no-indent"),
             offline: raw_args.contains("--offline"),
-            package: raw_args.opt_value_from_str("--manifest-path")?,
+            package: raw_args.opt_value_from_str(["-p", "--package"])?,
             prefix_depth: raw_args.contains("--prefix-depth"),
             quiet: raw_args.contains(["-q", "--quiet"]),
             readme_args: ReadmeArgs {


### PR DESCRIPTION
Fixes #195.

```console
pest v2.1.3 (/home/ryo/src/github.com/pest-parser/pest/pest)
└── ucd-trie v0.1.3
```

```console
❯ cargo geiger -p ucd-trie
    Checking ucd-trie v0.1.3
    Checking pest v2.1.3 (/home/ryo/src/github.com/pest-parser/pest/pest)
    Finished dev [unoptimized + debuginfo] target(s) in 1.51s
︙
Functions  Expressions  Impls  Traits  Methods  Dependency

2/2        57/57        0/0    0/0     2/2      !  pest 2.1.3
0/0        0/0          0/0    0/0     0/0      ?  └── ucd-trie 0.1.3

2/2        57/57        0/0    0/0     2/2
```

↓


```console
❯ cargo geiger -p ucd-trie
    Checking ucd-trie v0.1.3
    Checking pest v2.1.3 (/home/ryo/src/github.com/pest-parser/pest/pest)
    Finished dev [unoptimized + debuginfo] target(s) in 1.51s
︙
Functions  Expressions  Impls  Traits  Methods  Dependency

0/0        0/0          0/0    0/0     0/0      ?  ucd-trie 0.1.3

0/0        0/0          0/0    0/0     0/0
```
