### PR TITLE
Adds Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 1
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00" # UTC
+    reviewers:
+      - "pinkforest"
+    assignees:
+      - "pinkforest"
+    labels:
+      - "domain: deps"
+    commit-message:
+      prefix: "* RoboYak deps"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "domain: ci"
+    commit-message:
+      prefix: "* RoboYak CI"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
     schedule:
       interval: "daily"
       time: "02:00" # UTC
-    reviewers:
-      - "pinkforest"
-    assignees:
-      - "pinkforest"
     labels:
       - "domain: deps"
     commit-message:


### PR DESCRIPTION
https://deps.rs/repo/github/rust-secure-code/cargo-geiger

**Why?**

- We have some insecure dependencies
- https://deps.rs/repo/github/rust-secure-code/cargo-geiger
- Dependabot will PR (giving the choice) any outdated dependency and tells what has been updated

**Please note**

- Please enable dependabot under repo settings / security 
- Run manually via insights / dependency graph / dependabot (automatic daily otherwise)
- Add labels "deps" and "ci" for PRs so they can be searched/categorised