### PR TITLE
Maintenance release bump with deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,7 @@ updates:
     schedule:
       interval: "daily"
       time: "02:00" # UTC
-    labels:
-      - "domain: deps"
-    commit-message:
-      prefix: "* RoboYak deps"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "domain: ci"
-    commit-message:
-      prefix: "* RoboYak CI"

--- a/.github/workflows/rust-audit-check.yml
+++ b/.github/workflows/rust-audit-check.yml
@@ -6,7 +6,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.4.0
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -13,7 +13,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.4.0
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ---------
 
+## 0.11.2
+ - Upgraded dependencies including from Cargo 0.52.0 to 0.58.0 [#230], [#225]
+
 ## 0.11.1
  - Removed a failing test case that depended on the crate version.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
 name = "assert_cmd"
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-geiger"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-geiger-serde"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "semver",
  "serde",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "geiger"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "cargo-geiger-serde",
  "proc-macro2",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244"
+checksum = "86c4e56d571b4cc829f0ce71506bd865a90369eeab5f3d3657ba96230beb8012"
 dependencies = [
  "console 0.14.1",
  "lazy_static",
@@ -946,9 +946,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1073,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70072c20945e1ab871c472a285fc772aefd4f5407723c206242f2c6f94595d6"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pkg-config"
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1220,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1321,18 +1321,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1379,9 +1379,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "similar"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "sized-chunks"
@@ -1445,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "23a1dfb999630e338648c83e91c59a4e9fb7620f520c3194b6b89e276f2f1959"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 cargo-geiger ☢️ 
 ===============
 
-
-___Looking for maintainer: https://github.com/rust-secure-code/cargo-geiger/issues/210___
-
-
 [![Build Status](https://dev.azure.com/cargo-geiger/cargo-geiger/_apis/build/status/rust-secure-code.cargo-geiger?branchName=master)](https://dev.azure.com/cargo-geiger/cargo-geiger/_build/latest?definitionId=1&branchName=master)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 [![Code Coverage](https://img.shields.io/azure-devops/coverage/cargo-geiger/cargo-geiger/2/master)](https://img.shields.io/azure-devops/coverage/cargo-geiger/cargo-geiger/2/master)

--- a/cargo-geiger-serde/Cargo.toml
+++ b/cargo-geiger-serde/Cargo.toml
@@ -7,9 +7,9 @@ license = "Apache-2.0/MIT"
 keywords = ["unsafe"]
 name = "cargo-geiger-serde"
 repository = "https://github.com/rust-secure-code/cargo-geiger"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 semver = { version = "1.0.4", features = ["serde"] }
-serde = { version = "1.0.125", features = ["derive"] }
-url = { version = "2.2.1", features = ["serde"] }
+serde = { version = "1.0.132", features = ["derive"] }
+url = { version = "2.2.2", features = ["serde"] }

--- a/cargo-geiger/Cargo.toml
+++ b/cargo-geiger/Cargo.toml
@@ -8,25 +8,25 @@ license = "Apache-2.0/MIT"
 name = "cargo-geiger"
 readme = "README.md"
 repository = "https://github.com/rust-secure-code/cargo-geiger"
-version = "0.11.1"
+version = "0.11.2"
 
 [badges]
 maintenance = { status = "experimental" }
 
 [dependencies]
-anyhow = "1.0.40"
+anyhow = "1.0.52"
 cargo = "0.58.0"
-cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.0" }
+cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.1" }
 cargo_metadata = "0.14.1"
-cargo-platform = "0.1.1"
+cargo-platform = "0.1.2"
 colored = "2.0.0"
 console = "0.15.0"
-geiger = { path = "../geiger", version = "0.4.7" }
+geiger = { path = "../geiger", version = "0.4.8" }
 krates = "0.9.0"
 petgraph = "0.6.0"
-pico-args = "0.4.0"
-regex = "1.4.5"
-serde = { version = "1.0.125", features = ["derive"] }
+pico-args = "0.4.2"
+regex = "1.5.4"
+serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.64"
 strum = "0.23.0"
 strum_macros = "0.23.1"
@@ -41,9 +41,9 @@ vendored-openssl = ["cargo/vendored-openssl"]
 assert_cmd = "2.0.2"
 better-panic = "0.2.0"
 fs_extra = "1.2.0"
-insta = "1.7.1"
-rand = "0.8.3"
-regex = "1.4.5"
+insta = "1.9.0"
+rand = "0.8.4"
+regex = "1.5.4"
 rstest = "0.12.0"
 semver = "1.0.4"
 tempfile = "3.2.0"

--- a/geiger/Cargo.toml
+++ b/geiger/Cargo.toml
@@ -8,15 +8,15 @@ license = "Apache-2.0/MIT"
 name = "geiger"
 readme = "README.md"
 repository = "https://github.com/rust-secure-code/cargo-geiger"
-version = "0.4.7"
+version = "0.4.8"
 
 [badges]
 maintenance = { status = "experimental" }
 
 [dependencies]
-cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.0" }
-syn = { version = "1.0.67", features = ["parsing", "printing", "clone-impls", "full", "extra-traits", "visit"] }
-proc-macro2 = "1.0.24"
+cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.1" }
+syn = { version = "1.0.83", features = ["parsing", "printing", "clone-impls", "full", "extra-traits", "visit"] }
+proc-macro2 = "1.0.34"
 
 [dev-dependencies]
 rstest = "0.12.0"

--- a/geiger/README.md
+++ b/geiger/README.md
@@ -11,6 +11,9 @@ For more details please see the `README.md` in [cargo-geiger].
 Changelog
 ---------
 
+### 0.4.8
+ - Upgraded dependencies.
+
 ### 0.4.7
  - Reverted public API breakage from 0.4.6. [#204]
 


### PR DESCRIPTION
**Maintenance release**
- cargo-geiger 0.11.1 -> 0.11.2
- cargo-geiger-serde 0.2.0 -> 0.2.1
- geiger 0.4.7 -> 0.4.8

Bumps various deps as well as removes the annoyances with dependabot custom configuration.

Tests succeed and see no problems.