### PR TITLE
Allow to only analyze the root crate

### DIFF
--- a/cargo-geiger/src/args.rs
+++ b/cargo-geiger/src/args.rs
@@ -49,7 +49,6 @@ OPTIONS:
     -Z \"<FLAG>...\"                Unstable (nightly-only) flags to Cargo.
         --include-tests           Count unsafe usage in tests.
         --no-dependencies         Analyze no dependencies.
-        --dev-dependencies        Also analyze dev dependencies.
         --all-dependencies        Analyze all dependencies, including build and
                                   dev.
         --forbid-only             Don't build or clean anything, only scan
@@ -106,7 +105,6 @@ impl Args {
             deps_args: DepsArgs {
                 all_deps: raw_args.contains("--all-dependencies"),
                 no_deps: raw_args.contains("--no-dependencies"),
-                dev_deps: raw_args.contains("--dev-dependencies"),
             },
             features_args: FeaturesArgs {
                 all_features: raw_args.contains("--all-features"),
@@ -210,7 +208,6 @@ impl Args {
 pub struct DepsArgs {
     pub all_deps: bool,
     pub no_deps: bool,
-    pub dev_deps: bool,
 }
 
 #[derive(Debug, Default)]

--- a/cargo-geiger/src/args.rs
+++ b/cargo-geiger/src/args.rs
@@ -48,7 +48,7 @@ OPTIONS:
         --offline                 Run without accessing the network.
     -Z \"<FLAG>...\"                Unstable (nightly-only) flags to Cargo.
         --include-tests           Count unsafe usage in tests.
-        --build-dependencies      Also analyze build dependencies.
+        --no-dependencies         Analyze no dependencies.
         --dev-dependencies        Also analyze dev dependencies.
         --all-dependencies        Analyze all dependencies, including build and
                                   dev.
@@ -105,7 +105,7 @@ impl Args {
             color: raw_args.opt_value_from_str("--color")?,
             deps_args: DepsArgs {
                 all_deps: raw_args.contains("--all-dependencies"),
-                build_deps: raw_args.contains("--build-dependencies"),
+                no_deps: raw_args.contains("--no-dependencies"),
                 dev_deps: raw_args.contains("--dev-dependencies"),
             },
             features_args: FeaturesArgs {
@@ -209,7 +209,7 @@ impl Args {
 #[derive(Debug, Default)]
 pub struct DepsArgs {
     pub all_deps: bool,
-    pub build_deps: bool,
+    pub no_deps: bool,
     pub dev_deps: bool,
 }
 

--- a/cargo-geiger/src/format.rs
+++ b/cargo-geiger/src/format.rs
@@ -84,7 +84,7 @@ impl fmt::Display for FormatError {
 
 pub fn get_kind_group_name(dep_kind: DependencyKind) -> Option<&'static str> {
     match dep_kind {
-        DependencyKind::Build => Some("[build-dependencies]"),
+        DependencyKind::Build => None,
         DependencyKind::Development => Some("[dev-dependencies]"),
         DependencyKind::Normal => None,
         _ => panic!("Unrecognised Dependency Kind"),
@@ -115,10 +115,7 @@ mod format_tests {
 
     #[rstest]
     fn get_kind_group_name_test() {
-        assert_eq!(
-            get_kind_group_name(DependencyKind::Build),
-            Some("[build-dependencies]")
-        );
+        assert_eq!(get_kind_group_name(DependencyKind::Build), None);
 
         assert_eq!(
             get_kind_group_name(DependencyKind::Development),

--- a/cargo-geiger/src/format/table/handle_text_tree_line.rs
+++ b/cargo-geiger/src/format/table/handle_text_tree_line.rs
@@ -205,10 +205,7 @@ mod handle_text_tree_line_tests {
     #[rstest(
         input_dep_kind,
         expected_kind_group_name,
-        case(
-            DependencyKind::Build,
-            Some(String::from("[build-dependencies]"))
-        ),
+        case(DependencyKind::Build, None),
         case(
             DependencyKind::Development,
             Some(String::from("[dev-dependencies]"))

--- a/cargo-geiger/src/graph.rs
+++ b/cargo-geiger/src/graph.rs
@@ -152,8 +152,6 @@ fn build_graph_prerequisites<'a>(
         ExtraDeps::All
     } else if deps_args.no_deps {
         ExtraDeps::NoMore
-    } else if deps_args.dev_deps {
-        ExtraDeps::Dev
     } else {
         ExtraDeps::Build
     };
@@ -212,7 +210,6 @@ mod graph_tests {
             DepsArgs {
                 all_deps: true,
                 no_deps: false,
-                dev_deps: false
             },
             ExtraDeps::All
         ),
@@ -220,7 +217,6 @@ mod graph_tests {
             DepsArgs {
                 all_deps: false,
                 no_deps: true,
-                dev_deps: false
             },
             ExtraDeps::NoMore
         ),
@@ -228,15 +224,6 @@ mod graph_tests {
             DepsArgs {
                 all_deps: false,
                 no_deps: false,
-                dev_deps: true
-            },
-            ExtraDeps::Dev
-        ),
-        case(
-            DepsArgs {
-                all_deps: false,
-                no_deps: false,
-                dev_deps: false
             },
             ExtraDeps::Build
         )

--- a/cargo-geiger/src/graph.rs
+++ b/cargo-geiger/src/graph.rs
@@ -155,7 +155,7 @@ fn build_graph_prerequisites<'a>(
     } else if deps_args.dev_deps {
         ExtraDeps::Dev
     } else {
-        ExtraDeps::NoMore
+        ExtraDeps::Build
     };
 
     let target = if target_args.all_targets {

--- a/cargo-geiger/src/graph.rs
+++ b/cargo-geiger/src/graph.rs
@@ -150,8 +150,8 @@ fn build_graph_prerequisites<'a>(
 ) -> (ExtraDeps, Option<&'a str>) {
     let extra_deps = if deps_args.all_deps {
         ExtraDeps::All
-    } else if deps_args.build_deps {
-        ExtraDeps::Build
+    } else if deps_args.no_deps {
+        ExtraDeps::NoMore
     } else if deps_args.dev_deps {
         ExtraDeps::Dev
     } else {
@@ -211,7 +211,7 @@ mod graph_tests {
         case(
             DepsArgs {
                 all_deps: true,
-                build_deps: false,
+                no_deps: false,
                 dev_deps: false
             },
             ExtraDeps::All
@@ -219,15 +219,15 @@ mod graph_tests {
         case(
             DepsArgs {
                 all_deps: false,
-                build_deps: true,
+                no_deps: true,
                 dev_deps: false
             },
-            ExtraDeps::Build
+            ExtraDeps::NoMore
         ),
         case(
             DepsArgs {
                 all_deps: false,
-                build_deps: false,
+                no_deps: false,
                 dev_deps: true
             },
             ExtraDeps::Dev
@@ -235,10 +235,10 @@ mod graph_tests {
         case(
             DepsArgs {
                 all_deps: false,
-                build_deps: false,
+                no_deps: false,
                 dev_deps: false
             },
-            ExtraDeps::NoMore
+            ExtraDeps::Build
         )
     )]
     fn build_graph_prerequisites_extra_deps_test(

--- a/cargo-geiger/src/graph/extra_deps.rs
+++ b/cargo-geiger/src/graph/extra_deps.rs
@@ -4,7 +4,6 @@ use cargo_metadata::DependencyKind;
 pub enum ExtraDeps {
     All,
     Build,
-    Dev,
     NoMore,
 }
 
@@ -17,7 +16,6 @@ impl ExtraDeps {
             (ExtraDeps::NoMore, _) => false,
             (_, DependencyKind::Normal) => true,
             (ExtraDeps::Build, DependencyKind::Build) => true,
-            (ExtraDeps::Dev, DependencyKind::Development) => true,
             _ => false,
         }
     }
@@ -34,14 +32,9 @@ mod extra_deps_tests {
         expected_allows,
         case(ExtraDeps::All, DependencyKind::Normal, true),
         case(ExtraDeps::Build, DependencyKind::Normal, true),
-        case(ExtraDeps::Dev, DependencyKind::Normal, true),
         case(ExtraDeps::NoMore, DependencyKind::Normal, false),
         case(ExtraDeps::All, DependencyKind::Build, true),
-        case(ExtraDeps::All, DependencyKind::Development, true),
         case(ExtraDeps::Build, DependencyKind::Build, true),
-        case(ExtraDeps::Build, DependencyKind::Development, false),
-        case(ExtraDeps::Dev, DependencyKind::Build, false),
-        case(ExtraDeps::Dev, DependencyKind::Development, true)
     )]
     fn extra_deps_allows_test(
         input_extra_deps: ExtraDeps,

--- a/cargo-geiger/src/graph/extra_deps.rs
+++ b/cargo-geiger/src/graph/extra_deps.rs
@@ -13,8 +13,9 @@ impl ExtraDeps {
     #[allow(clippy::match_like_matches_macro)]
     pub fn allows(&self, dependency_kind: DependencyKind) -> bool {
         match (self, dependency_kind) {
-            (_, DependencyKind::Normal) => true,
             (ExtraDeps::All, _) => true,
+            (ExtraDeps::NoMore, _) => false,
+            (_, DependencyKind::Normal) => true,
             (ExtraDeps::Build, DependencyKind::Build) => true,
             (ExtraDeps::Dev, DependencyKind::Development) => true,
             _ => false,
@@ -34,7 +35,7 @@ mod extra_deps_tests {
         case(ExtraDeps::All, DependencyKind::Normal, true),
         case(ExtraDeps::Build, DependencyKind::Normal, true),
         case(ExtraDeps::Dev, DependencyKind::Normal, true),
-        case(ExtraDeps::NoMore, DependencyKind::Normal, true),
+        case(ExtraDeps::NoMore, DependencyKind::Normal, false),
         case(ExtraDeps::All, DependencyKind::Build, true),
         case(ExtraDeps::All, DependencyKind::Development, true),
         case(ExtraDeps::Build, DependencyKind::Build, true),


### PR DESCRIPTION
This is a draft for #190.

I deleted the cli options `--build-dependencies` & `--dev-dependencies`, and added `--no-dependencies`.

Build dependencies are evaluated in every run. This maps to the the current version of cargo geiger (even if the `--build-dependencies` flag was not set).

The output for the `sha2` crate looks like this:

```
8/8        192/192      0/0    0/0     0/0      !  sha2 0.10.0
0/0        0/0          0/0    0/0     0/0      ?  |-- cfg-if 1.0.0
0/1        0/14         0/0    0/0     0/0      ?  |-- cpufeatures 0.2.1
0/0        0/0          0/0    0/0     0/0      :) `-- digest 0.10.1
0/0        0/0          0/0    0/0     0/0      ?      |-- blobby 0.3.1
0/0        16/16        0/0    0/0     0/0      !      |-- block-buffer 0.10.0
1/1        295/295      20/20  8/8     5/5      !      |   `-- generic-array 0.14.4
0/0        0/0          0/0    0/0     0/0      :)     |       `-- typenum 1.15.0
0/0        0/0          0/0    0/0     0/0      ?      |       `-- version_check 0.9.4
0/0        0/0          0/0    0/0     0/0      :)     |-- crypto-common 0.1.1
1/1        295/295      20/20  8/8     5/5      !      |   `-- generic-array 0.14.4
1/1        295/295      20/20  8/8     5/5      !      |-- generic-array 0.14.4
0/0        0/3          0/0    0/0     0/0      ?      `-- subtle 2.4.1

9/10       503/520      20/20  8/8     5/5 
```

`--no-dependencies`:
``` 
8/8        192/192      0/0    0/0     0/0      !  sha2 0.10.0

8/8        192/192      0/0    0/0     0/0 
```

`--all-dependencies`:
``` 
8/8        192/192      0/0    0/0     0/0      !  sha2 0.10.0
0/0        0/0          0/0    0/0     0/0      ?  |-- cfg-if 1.0.0
0/1        0/14         0/0    0/0     0/0      ?  |-- cpufeatures 0.2.1
0/0        0/0          0/0    0/0     0/0      :) `-- digest 0.10.1
0/0        0/0          0/0    0/0     0/0      ?      |-- blobby 0.3.1
0/0        16/16        0/0    0/0     0/0      !      |-- block-buffer 0.10.0
1/1        295/295      20/20  8/8     5/5      !      |   `-- generic-array 0.14.4
0/0        0/0          0/0    0/0     0/0      ?      |       `-- version_check 0.9.4
0/0        0/0          0/0    0/0     0/0      :)     |       `-- typenum 1.15.0
0/0        0/0          0/0    0/0     0/0      :)     |-- crypto-common 0.1.1
1/1        295/295      20/20  8/8     5/5      !      |   `-- generic-array 0.14.4
1/1        295/295      20/20  8/8     5/5      !      |-- generic-array 0.14.4
0/0        0/3          0/0    0/0     0/0      ?      `-- subtle 2.4.1
                                                       [dev-dependencies]
0/0        0/0          0/0    0/0     0/0      :) |-- digest 0.10.1
0/0        0/0          0/0    0/0     0/0      ?  `-- hex-literal 0.2.1
0/0        0/0          0/0    0/0     0/0      ?      |-- hex-literal-impl 0.2.2
0/0        0/0          0/0    0/0     0/0      ?      |   `-- proc-macro-hack 0.5.19
0/0        0/0          0/0    0/0     0/0      ?      `-- proc-macro-hack 0.5.19

9/10       503/520      20/20  8/8     5/5 
```