### PR TITLE
Fix `Failed to match` errors in cargo-geiger

### DIFF
--- a/cargo-geiger/src/graph.rs
+++ b/cargo-geiger/src/graph.rs
@@ -51,7 +51,7 @@ pub fn build_graph<'a>(
         graph.graph.add_node(root_package_id.clone()),
     );
 
-    let mut pending_packages = vec![root_package_id];
+    let mut pending_packages = vec![root_package_id.clone()];
 
     let graph_configuration = GraphConfiguration {
         target,
@@ -60,12 +60,14 @@ pub fn build_graph<'a>(
     };
 
     while let Some(package_id) = pending_packages.pop() {
+        let is_root_package = package_id == root_package_id;
         add_package_dependencies_to_graph(
             cargo_metadata_parameters,
             package_id,
             &graph_configuration,
             &mut graph,
             &mut pending_packages,
+            is_root_package,
         );
     }
 
@@ -104,6 +106,7 @@ fn add_package_dependencies_to_graph(
     graph_configuration: &GraphConfiguration,
     graph: &mut Graph,
     pending_packages: &mut Vec<PackageId>,
+    is_root_package: bool,
 ) {
     let index = graph.nodes[&package_id];
 
@@ -112,7 +115,7 @@ fn add_package_dependencies_to_graph(
 
     let dep_not_replaced_option = cargo_metadata_parameters
         .metadata
-        .deps_not_replaced(&package_id);
+        .deps_not_replaced(&package_id, is_root_package);
 
     match (krates_node_option, dep_not_replaced_option) {
         (Some(krates_node), Some(dependencies)) => {

--- a/cargo-geiger/src/mapping.rs
+++ b/cargo-geiger/src/mapping.rs
@@ -35,6 +35,7 @@ pub trait DepsNotReplaced {
     fn deps_not_replaced<T: ToCargoMetadataPackage + Display>(
         &self,
         package_id: &T,
+        is_root_package: bool,
     ) -> Option<Vec<(CargoMetadataPackageId, HashSet<CargoMetadataDependency>)>>;
 }
 
@@ -72,7 +73,10 @@ pub trait GetPackageRoot: GetPackageInformation {
 }
 
 pub trait MatchesIgnoringSource {
-    fn matches_ignoring_source<T: GetNodeForKid, U: GetPackageIdInformation>(
+    fn matches_ignoring_source<
+        T: GetNodeForKid,
+        U: GetPackageIdInformation + Display,
+    >(
         &self,
         krates: &T,
         package_id: &U,


### PR DESCRIPTION
This fixes the issue with `Failed to match` errors, which was caused by cargo-metadata behaviour of not resolving dev-dependencies of crate dependency. 

Now we check if crate is root and if not, we won't collect dev deps for this package, cause they are anyways not in krates graph, which relies on cargo-metadata `resolve` output field.

Also changed argument for `Failed to match` error, cause it mentioned
not the real one unmatched package.

Relates to #240