### PR TITLE
Optimize docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,10 @@
-Dockerfile
-/target/
-/test_crates/**/target/
+# ignore all files not explicily included
+*
+!/Cargo.toml
+!/Cargo.lock
+!/cargo-geiger/Cargo.toml
+!/cargo-geiger/src/
+!/cargo-geiger-serde/Cargo.toml
+!/cargo-geiger-serde/src/
+!/geiger/Cargo.toml
+!/geiger/src/

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,9 @@
+name: docker
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,9 @@ COPY . .
 RUN cargo build --release --offline --locked --frozen --bin cargo-geiger
 
 FROM rust:slim as runtime
-ENV PATH=$PATH:/usr/local/cargo/bin
 RUN apt-get update \
     && apt-get install --no-install-recommends -y libcurl4 \
     && apt-get clean
 WORKDIR "/workdir"
-COPY --from=chef /usr/local/cargo /usr/local/cargo
 COPY --from=builder /app/target/release/cargo-geiger /usr/local/bin/cargo-geiger
 ENTRYPOINT ["cargo-geiger"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --offline --locked --frozen --bin cargo-geiger
 
-FROM debian:bullseye-slim as runtime
+FROM rust:slim as runtime
 ENV PATH=$PATH:/usr/local/cargo/bin
 RUN apt-get update \
     && apt-get install --no-install-recommends -y libcurl4 \

--- a/run-docker
+++ b/run-docker
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s inherit_errexit
+
+PWD=$(pwd)
+DOCKER_BUILDKIT=1 docker build -t cargo-geiger:dev .
+
+exec docker run -it --rm \
+  -v "${PWD}:/workdir:ro" \
+  --name cargo-geiger \
+  cargo-geiger:dev \
+  "$@"


### PR DESCRIPTION
Clean builds are a little bit faster now and builds that can make use of the cache should be significantly faster. The resulting image is also much smaller now.

Here's what I changed:
- I added a github workflow that builds the docker image
- I reorganized the `Dockerfle`
- I updated `.dockerignore` to ignore almost everything
- I added a shell script to the repo root to create and run the image
