### PR TITLE
chore(release): cargo-geiger 0.11.3, geiger 0.4.9, cargo-geiger-serde 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ---------
 
+## 0.11.3
+ - Add threaded scanning [#268]
+ - Upgraded dependencies including from Cargo 0.58.0 to 0.60.0 [#251], [#275]
+
 ## 0.11.2
  - Upgraded dependencies including from Cargo 0.52.0 to 0.58.0 [#230], [#225]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-geiger"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-geiger-serde"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "semver",
  "serde",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "geiger"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "cargo-geiger-serde",
  "proc-macro2",

--- a/cargo-geiger-serde/Cargo.toml
+++ b/cargo-geiger-serde/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0/MIT"
 keywords = ["unsafe"]
 name = "cargo-geiger-serde"
 repository = "https://github.com/rust-secure-code/cargo-geiger"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 semver = { version = "1.0.9", features = ["serde"] }

--- a/cargo-geiger/Cargo.toml
+++ b/cargo-geiger/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0/MIT"
 name = "cargo-geiger"
 readme = "README.md"
 repository = "https://github.com/rust-secure-code/cargo-geiger"
-version = "0.11.2"
+version = "0.11.3"
 
 [badges]
 maintenance = { status = "experimental" }
@@ -16,12 +16,12 @@ maintenance = { status = "experimental" }
 [dependencies]
 anyhow = "1.0.57"
 cargo = "0.60.0"
-cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.1" }
+cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.2" }
 cargo_metadata = "0.14.2"
 cargo-platform = "0.1.2"
 colored = "2.0.0"
 console = "0.15.0"
-geiger = { path = "../geiger", version = "0.4.8" }
+geiger = { path = "../geiger", version = "0.4.9" }
 krates = "0.10.1"
 petgraph = "0.6.0"
 pico-args = "0.4.2"

--- a/geiger/Cargo.toml
+++ b/geiger/Cargo.toml
@@ -8,13 +8,13 @@ license = "Apache-2.0/MIT"
 name = "geiger"
 readme = "README.md"
 repository = "https://github.com/rust-secure-code/cargo-geiger"
-version = "0.4.8"
+version = "0.4.9"
 
 [badges]
 maintenance = { status = "experimental" }
 
 [dependencies]
-cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.1" }
+cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.2" }
 syn = { version = "1.0.95", features = ["parsing", "printing", "clone-impls", "full", "extra-traits", "visit"] }
 proc-macro2 = "1.0.39"
 


### PR DESCRIPTION
## 0.11.3
 - Bump cargo-geiger 0.11.3, geiger 0.4.9, cargo-geiger-serde 0.2.2
 - Add threaded scanning [#268]
 - Upgraded dependencies including from Cargo 0.58.0 to 0.60.0 [#251], [#275]