### PR TITLE
ISSUE-69 - Remove usage of `cargo::core::shell::Verbosity` where

### DIFF
--- a/cargo-geiger/src/args.rs
+++ b/cargo-geiger/src/args.rs
@@ -86,21 +86,9 @@ pub struct Args {
     pub readme_args: ReadmeArgs,
     pub target_args: TargetArgs,
     pub unstable_flags: Vec<String>,
-    //pub verbose: u32,
     pub verbosity: Verbosity,
     pub version: bool,
 }
-
-/*
-           verbose: match (
-               raw_args.contains("-vv"),
-               raw_args.contains(["-v", "--verbose"]),
-           ) {
-               (false, false) => 0,
-               (false, true) => 1,
-               (true, _) => 2,
-           },
-*/
 
 impl Args {
     /// Construct `Args` struct from `pico_args::Arguments` loaded from command line arguments

--- a/cargo-geiger/src/args.rs
+++ b/cargo-geiger/src/args.rs
@@ -1,3 +1,4 @@
+use crate::args::Verbosity::{Normal, Quiet, Verbose};
 use crate::format::print_config::OutputFormat;
 
 use cargo::core::shell::ColorChoice;
@@ -85,9 +86,21 @@ pub struct Args {
     pub readme_args: ReadmeArgs,
     pub target_args: TargetArgs,
     pub unstable_flags: Vec<String>,
-    pub verbose: u32,
+    //pub verbose: u32,
+    pub verbosity: Verbosity,
     pub version: bool,
 }
+
+/*
+           verbose: match (
+               raw_args.contains("-vv"),
+               raw_args.contains(["-v", "--verbose"]),
+           ) {
+               (false, false) => 0,
+               (false, true) => 1,
+               (true, _) => 2,
+           },
+*/
 
 impl Args {
     /// Construct `Args` struct from `pico_args::Arguments` loaded from command line arguments
@@ -143,15 +156,16 @@ impl Args {
                 .opt_value_from_str("-Z")?
                 .map(|s: String| s.split(' ').map(|s| s.to_owned()).collect())
                 .unwrap_or_else(Vec::new),
-            verbose: match (
+
+            version: raw_args.contains(["-V", "--version"]),
+            verbosity: match (
                 raw_args.contains("-vv"),
                 raw_args.contains(["-v", "--verbose"]),
             ) {
-                (false, false) => 0,
-                (false, true) => 1,
-                (true, _) => 2,
+                (false, false) => Quiet,
+                (false, true) => Normal,
+                (true, _) => Verbose,
             },
-            version: raw_args.contains(["-V", "--version"]),
             output_format: raw_args
                 .opt_value_from_str("--output-format")?
                 .unwrap_or(OutputFormat::Utf8),
@@ -184,8 +198,14 @@ impl Args {
     /// ```
     pub fn update_config(&self, config: &mut Config) -> CliResult {
         let target_dir = None; // Doesn't add any value for cargo-geiger.
+        let cargo_config_verbosity = match self.verbosity {
+            Quiet => 0,
+            Normal => 1,
+            Verbose => 2,
+        };
+
         config.configure(
-            self.verbose,
+            cargo_config_verbosity,
             self.quiet,
             self.color.as_deref(),
             self.frozen,
@@ -233,6 +253,19 @@ pub struct ReadmeArgs {
     pub update_readme: bool,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum Verbosity {
+    Verbose,
+    Normal,
+    Quiet,
+}
+
+impl Default for Verbosity {
+    fn default() -> Self {
+        Verbose
+    }
+}
+
 fn parse_features(raw_features: Option<String>) -> Vec<String> {
     raw_features
         .as_ref()
@@ -249,7 +282,7 @@ pub mod args_tests {
     use super::*;
 
     use cargo::core::shell::ColorChoice;
-    use cargo::core::Verbosity;
+    use cargo::core::Verbosity as CargoCoreVerbosity;
     use rstest::*;
     use std::ffi::OsString;
 
@@ -257,55 +290,55 @@ pub mod args_tests {
         input_argument_vector,
         expected_all,
         expected_output_format,
-        expected_verbose,
+        expected_verbosity,
         case(
             vec![],
             false,
             OutputFormat::Utf8,
-            0
+            Quiet
         ),
         case(
             vec![OsString::from("--all")],
             true,
             OutputFormat::Utf8,
-            0,
+            Quiet,
         ),
         case(
             vec![OsString::from("--output-format"), OsString::from("Ascii")],
             false,
             OutputFormat::Ascii,
-            0
+            Quiet
         ),
         case(
             vec![OsString::from("-v")],
             false,
             OutputFormat::Utf8,
-            1
+            Normal
         ),
         case(
             vec![OsString::from("-vv")],
             false,
             OutputFormat::Utf8,
-            2
+            Verbose
         ),
         case(
             vec![OsString::from("--update-readme")],
             false,
             OutputFormat::GitHubMarkdown,
-            0
+            Quiet
         ),
         case(
             vec![OsString::from("--update-readme"), OsString::from("--output-format"), OsString::from("Ascii")],
             false,
             OutputFormat::GitHubMarkdown,
-            0
+            Quiet
         )
     )]
     fn parse_args_test(
         input_argument_vector: Vec<OsString>,
         expected_all: bool,
         expected_output_format: OutputFormat,
-        expected_verbose: u32,
+        expected_verbosity: Verbosity,
     ) {
         let args_result =
             Args::parse_args(Arguments::from_vec(input_argument_vector));
@@ -316,7 +349,7 @@ pub mod args_tests {
 
         assert_eq!(args.all, expected_all);
         assert_eq!(args.output_format, expected_output_format);
-        assert_eq!(args.verbose, expected_verbose)
+        assert_eq!(args.verbosity, expected_verbosity)
     }
 
     #[rstest(
@@ -352,25 +385,25 @@ pub mod args_tests {
 
     #[rstest(
         input_quiet,
-        input_verbose,
+        input_verbosity,
         expected_extra_verbose,
         expected_shell_verbosity,
-        case(true, 0, false, Verbosity::Quiet),
-        case(false, 0, false, Verbosity::Normal),
-        case(false, 1, false, Verbosity::Verbose),
-        case(false, 2, true, Verbosity::Verbose)
+        case(true, Quiet, false, CargoCoreVerbosity::Quiet),
+        case(false, Quiet, false, CargoCoreVerbosity::Normal),
+        case(false, Normal, false, CargoCoreVerbosity::Verbose),
+        case(false, Verbose, true, CargoCoreVerbosity::Verbose)
     )]
     fn update_config_test_verbosity(
         input_quiet: bool,
-        input_verbose: u32,
+        input_verbosity: Verbosity,
         expected_extra_verbose: bool,
-        expected_shell_verbosity: Verbosity,
+        expected_shell_verbosity: CargoCoreVerbosity,
     ) {
         let offline = rand::random();
         let args = Args {
             offline,
             quiet: input_quiet,
-            verbose: input_verbose,
+            verbosity: input_verbosity,
             ..Default::default()
         };
         let mut config = Config::default().unwrap();

--- a/cargo-geiger/src/format/print_config.rs
+++ b/cargo-geiger/src/format/print_config.rs
@@ -2,7 +2,6 @@ use crate::args::Args;
 use crate::format::pattern::Pattern;
 use crate::format::{CrateDetectionStatus, FormatError};
 
-use cargo::core::shell::Verbosity;
 use cargo::util::errors::CliError;
 use colored::{ColoredString, Colorize};
 use geiger::IncludeTests;
@@ -46,7 +45,6 @@ pub struct PrintConfig {
     pub include_tests: IncludeTests,
     pub prefix: Prefix,
     pub output_format: OutputFormat,
-    pub verbosity: Verbosity,
 }
 
 impl PrintConfig {
@@ -80,11 +78,6 @@ impl PrintConfig {
             (false, false) => Prefix::Indent,
         };
 
-        let verbosity = match args.verbose {
-            0 => Verbosity::Normal,
-            _ => Verbosity::Verbose,
-        };
-
         Ok(PrintConfig {
             all: args.all,
             allow_partial_results,
@@ -93,7 +86,6 @@ impl PrintConfig {
             include_tests,
             output_format: args.output_format,
             prefix,
-            verbosity,
         })
     }
 }
@@ -108,7 +100,6 @@ impl Default for PrintConfig {
             include_tests: IncludeTests::Yes,
             prefix: Prefix::Depth,
             output_format: Default::default(),
-            verbosity: Verbosity::Verbose,
         }
     }
 }
@@ -246,28 +237,6 @@ mod print_config_tests {
 
         assert!(print_config_result.is_ok());
         assert_eq!(print_config_result.unwrap().prefix, expected_output_prefix);
-    }
-
-    #[rstest(
-        input_verbosity_u32,
-        expected_verbosity,
-        case(0, Verbosity::Normal),
-        case(1, Verbosity::Verbose),
-        case(1, Verbosity::Verbose)
-    )]
-    fn print_config_new_test_verbosity(
-        input_verbosity_u32: u32,
-        expected_verbosity: Verbosity,
-    ) {
-        let args = Args {
-            verbose: input_verbosity_u32,
-            ..Default::default()
-        };
-
-        let print_config_result = PrintConfig::new(&args);
-
-        assert!(print_config_result.is_ok());
-        assert_eq!(print_config_result.unwrap().verbosity, expected_verbosity);
     }
 
     #[rstest(

--- a/cargo-geiger/src/scan/default/table.rs
+++ b/cargo-geiger/src/scan/default/table.rs
@@ -1,3 +1,4 @@
+use crate::args::Verbosity;
 use crate::format::emoji_symbols::EmojiSymbols;
 use crate::format::print_config::OutputFormat;
 use crate::format::table::{
@@ -14,7 +15,6 @@ use super::super::{
 };
 use super::scan;
 
-use cargo::core::shell::Verbosity;
 use cargo::core::Workspace;
 use cargo::CliError;
 use cargo_metadata::PackageId;
@@ -34,7 +34,7 @@ pub fn scan_to_table(
         geiger_context,
     } = scan(cargo_metadata_parameters, scan_parameters, workspace)?;
 
-    if scan_parameters.print_config.verbosity == Verbosity::Verbose {
+    if scan_parameters.args.verbosity != Verbosity::Quiet {
         let mut rs_files_used_lines =
             construct_rs_files_used_lines(&rs_files_used);
         combined_scan_output_lines.append(&mut rs_files_used_lines);

--- a/cargo-geiger/src/tree.rs
+++ b/cargo-geiger/src/tree.rs
@@ -83,7 +83,6 @@ mod tree_tests {
     use crate::format::pattern::Pattern;
     use crate::format::print_config::OutputFormat;
 
-    use cargo::core::shell::Verbosity;
     use geiger::IncludeTests;
     use petgraph::EdgeDirection;
     use rstest::*;
@@ -129,7 +128,6 @@ mod tree_tests {
         let pattern = Pattern::try_build("{p}").unwrap();
         PrintConfig {
             all: false,
-            verbosity: Verbosity::Verbose,
             direction: EdgeDirection::Outgoing,
             prefix,
             format: pattern,

--- a/cargo-geiger/src/tree/traversal/dependency_node.rs
+++ b/cargo-geiger/src/tree/traversal/dependency_node.rs
@@ -94,7 +94,6 @@ mod dependency_node_tests {
     use crate::format::pattern::Pattern;
     use crate::format::print_config::{OutputFormat, Prefix, PrintConfig};
 
-    use cargo::core::Verbosity;
     use cargo_metadata::DependencyKind;
     use geiger::IncludeTests;
     use petgraph::graph::NodeIndex;
@@ -225,7 +224,6 @@ mod dependency_node_tests {
             include_tests: IncludeTests::Yes,
             prefix: Prefix::Depth,
             output_format: OutputFormat::Ascii,
-            verbosity: Verbosity::Verbose,
         }
     }
 }


### PR DESCRIPTION
possible, and replace with internal `args` representation