### PR TITLE
NOISSUE - Make cargo clippy recommended changes:

### DIFF
--- a/cargo-geiger-serde/src/report.rs
+++ b/cargo-geiger-serde/src/report.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 /// Package dependency information
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PackageInfo {
     pub id: PackageId,
     #[serde(serialize_with = "set_serde::serialize")]
@@ -38,7 +38,7 @@ impl PackageInfo {
 }
 
 /// Entry of the report generated from scanning for packages that forbid the use of `unsafe`
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct QuickReportEntry {
     pub package: PackageInfo,
     /// Whether this package forbids the use of `unsafe`
@@ -46,7 +46,7 @@ pub struct QuickReportEntry {
 }
 
 /// Report generated from scanning for packages that forbid the use of `unsafe`
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct QuickSafetyReport {
     /// Packages that were scanned successfully
     #[serde(with = "entry_serde")]
@@ -57,7 +57,7 @@ pub struct QuickSafetyReport {
 }
 
 /// Entry of the report generated from scanning for the use of `unsafe`
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ReportEntry {
     pub package: PackageInfo,
     /// Unsafety scan results
@@ -65,7 +65,7 @@ pub struct ReportEntry {
 }
 
 /// Report generated from scanning for the use of `unsafe`
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SafetyReport {
     #[serde(with = "entry_serde")]
     pub packages: HashMap<PackageId, ReportEntry>,
@@ -76,7 +76,7 @@ pub struct SafetyReport {
 }
 
 /// Unsafety usage in a package
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct UnsafeInfo {
     /// Unsafe usage statistics for code used by the project
     pub used: CounterBlock,
@@ -98,7 +98,7 @@ pub enum DependencyKind {
 }
 
 /// Statistics about the use of `unsafe`
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Count {
     /// Number of safe items
     pub safe: u64,
@@ -135,7 +135,7 @@ impl AddAssign for Count {
 }
 
 /// Unsafe usage metrics collection.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CounterBlock {
     pub functions: Count,
     pub exprs: Count,

--- a/cargo-geiger/src/args.rs
+++ b/cargo-geiger/src/args.rs
@@ -241,7 +241,7 @@ pub struct ReadmeArgs {
     pub update_readme: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Verbosity {
     Verbose,
     Normal,

--- a/cargo-geiger/src/format.rs
+++ b/cargo-geiger/src/format.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::str::{self, FromStr};
 use strum_macros::EnumIter;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Charset {
     Ascii,
     GitHubMarkdown,
@@ -24,7 +24,7 @@ impl Default for Charset {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Chunk {
     License,
     Package,
@@ -46,14 +46,14 @@ impl FromStr for Charset {
     }
 }
 
-#[derive(Debug, Clone, EnumIter, PartialEq)]
+#[derive(Debug, Clone, EnumIter, Eq, PartialEq)]
 pub enum CrateDetectionStatus {
     NoneDetectedForbidsUnsafe,
     NoneDetectedAllowsUnsafe,
     UnsafeDetected,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum RawChunk<'a> {
     Argument(&'a str),
     Error(&'static str),

--- a/cargo-geiger/src/format/pattern.rs
+++ b/cargo-geiger/src/format/pattern.rs
@@ -7,7 +7,7 @@ use super::display::Display;
 use cargo_metadata::PackageId;
 use std::error::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Pattern {
     pub chunks: Vec<Chunk>,
 }

--- a/cargo-geiger/src/format/print_config.rs
+++ b/cargo-geiger/src/format/print_config.rs
@@ -8,7 +8,7 @@ use geiger::IncludeTests;
 use petgraph::{Direction, EdgeDirection};
 use strum_macros::EnumString;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Prefix {
     Depth,
     Indent,
@@ -30,7 +30,7 @@ impl Default for OutputFormat {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PrintConfig {
     /// Don't truncate dependencies that have already been displayed.
     pub all: bool,

--- a/cargo-geiger/src/graph/extra_deps.rs
+++ b/cargo-geiger/src/graph/extra_deps.rs
@@ -1,6 +1,6 @@
 use cargo_metadata::DependencyKind;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ExtraDeps {
     All,
     Build,

--- a/cargo-geiger/src/scan/rs_file.rs
+++ b/cargo-geiger/src/scan/rs_file.rs
@@ -22,7 +22,7 @@ use walkdir::{DirEntry, WalkDir};
 /// Provides information needed to scan for crate root
 /// `#![forbid(unsafe_code)]`.
 /// The wrapped `PathBufs` are canonicalized.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum RsFile {
     /// Executable entry point source file, usually src/main.rs
     BinRoot(PathBuf),

--- a/cargo-geiger/src/tree.rs
+++ b/cargo-geiger/src/tree.rs
@@ -1,12 +1,13 @@
 pub mod traversal;
 
 use crate::format::print_config::{OutputFormat, Prefix, PrintConfig};
+use std::fmt::Write as _;
 
 use cargo_metadata::{DependencyKind, PackageId};
 
 /// A step towards decoupling some parts of the table-tree printing from the
 /// dependency graph traversal.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum TextTreeLine {
     /// A text line for a package
     Package { id: PackageId, tree_vines: String },
@@ -18,7 +19,7 @@ pub enum TextTreeLine {
     },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct TreeSymbols {
     pub down: &'static str,
     pub tee: &'static str,
@@ -40,14 +41,14 @@ fn construct_tree_vines_string(
             {
                 for &continues in rest {
                     let c = if continues { tree_symbols.down } else { " " };
-                    buffer.push_str(&format!("{}   ", c));
+                    (write!(buffer, "{}   ", c)).unwrap();
                 }
                 let c = if last_continues {
                     tree_symbols.tee
                 } else {
                     tree_symbols.ell
                 };
-                buffer.push_str(&format!("{0}{1}{1} ", c, tree_symbols.right));
+                (write!(buffer, "{0}{1}{1} ", c, tree_symbols.right)).unwrap();
             }
             buffer
         }

--- a/cargo-geiger/src/tree/traversal/dependency_kind.rs
+++ b/cargo-geiger/src/tree/traversal/dependency_kind.rs
@@ -6,6 +6,7 @@ use crate::tree::{get_tree_symbols, TextTreeLine, TreeSymbols};
 use super::dependency_node::walk_dependency_node;
 
 use cargo_metadata::{DependencyKind, PackageId};
+use std::fmt::Write as _;
 use std::iter::Peekable;
 use std::slice::Iter;
 
@@ -75,9 +76,9 @@ fn push_extra_deps_group_text_tree_line_for_non_normal_dependencies(
         DependencyKind::Normal => (),
         _ => {
             let mut tree_vines = String::new();
-            for &continues in &*levels_continue {
+            for &continues in levels_continue {
                 let c = if continues { tree_symbols.down } else { " " };
-                tree_vines.push_str(&format!("{}   ", c))
+                (write!(tree_vines, "{}   ", c)).unwrap()
             }
             text_tree_lines.push(TextTreeLine::ExtraDepsGroup {
                 kind: dep_kind,

--- a/geiger/src/lib.rs
+++ b/geiger/src/lib.rs
@@ -27,7 +27,7 @@ pub enum IncludeTests {
 }
 
 /// Scan result for a single `.rs` file.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct RsFileMetrics {
     /// Metrics storage.
     pub counters: CounterBlock,


### PR DESCRIPTION
* `format_push_string` - avoid an extra allocation by using `write!` to
  append to an existing string, instead of `format!`
* `derive_partial_eq_without_eq` - ensure that all structs that both
  derive `PartialEq` and contain only members that derive `Eq` also
  derive `Eq`