### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
  - Clean up error handling, remove unwrap() calls, logging. [#188]
  - Update lint enforcement level based on issue. [#189]
  - Implement Display for FoundWarningsError instead of relying on Debug. [#191]
- - Add futher testing. [#192]
+ - Add further testing. [#192]
  - Fix Args::parse_args for -p option. [#196]
  - Refactor mapping module to use traits. [#197]
  - Fix into target kind function logic. [#198]

--- a/cargo-geiger/src/tree/traversal.rs
+++ b/cargo-geiger/src/tree/traversal.rs
@@ -35,7 +35,7 @@ pub fn walk_dependency_tree(
     let mut visited_deps = HashSet::new();
     let mut levels_continue = vec![];
 
-    let mut walk_dependency_paramters = WalkDependencyParameters {
+    let mut walk_dependency_parameters = WalkDependencyParameters {
         graph,
         levels_continue: &mut levels_continue,
         print_config,
@@ -46,6 +46,6 @@ pub fn walk_dependency_tree(
     walk_dependency_node(
         cargo_metadata_parameters,
         node,
-        &mut walk_dependency_paramters,
+        &mut walk_dependency_parameters,
     )
 }

--- a/cargo-geiger/tests/context/mod.rs
+++ b/cargo-geiger/tests/context/mod.rs
@@ -25,7 +25,7 @@ impl Context {
             .expect("Failed to canonicalize temporary path");
         // Canonicalizing on Windows returns a UNC path (starting with `\\?\`).
         // `cargo build` (as of 1.47.0) fails to use an overriding path dependency if the manifest
-        // given to `cargo build` is a UNC path. Roudtripping to URL gets rid of the UNC prefix.
+        // given to `cargo build` is a UNC path. Roundtripping to URL gets rid of the UNC prefix.
         let path = if cfg!(windows) {
             Url::from_file_path(path)
                 .expect("URL from path must succeed")


### PR DESCRIPTION
This PR fixes a few typos (trial run for [a CLI I made](https://github.com/Lioness100/rspell))
![ItAin'TMuch,ButIt'SHonestWork GIF](https://user-images.githubusercontent.com/65814829/219959048-6067915b-5e14-414d-a81a-a1d1c97cec33.gif)

:rofl: