### PR TITLE
Fix panic when git dependency does not declare revision

### DIFF
--- a/cargo-geiger/src/mapping/geiger.rs
+++ b/cargo-geiger/src/mapping/geiger.rs
@@ -47,7 +47,7 @@ fn handle_source_repr(source_repr: &str) -> CargoGeigerSerdeSource {
                 .query_pairs()
                 .find(|(query_key, _)| query_key == "rev")
                 .map(|(_, rev)| String::from(rev))
-                .unwrap_or_else(String::new);
+                .unwrap_or_default();
 
             CargoGeigerSerdeSource::Git {
                 url: Url::parse(&git_url_without_query).unwrap(),

--- a/cargo-geiger/src/mapping/geiger.rs
+++ b/cargo-geiger/src/mapping/geiger.rs
@@ -46,12 +46,12 @@ fn handle_source_repr(source_repr: &str) -> CargoGeigerSerdeSource {
             let revision = raw_git_url
                 .query_pairs()
                 .find(|(query_key, _)| query_key == "rev")
-                .unwrap()
-                .1;
+                .map(|(_, rev)| String::from(rev))
+                .unwrap_or_else(String::new);
 
             CargoGeigerSerdeSource::Git {
                 url: Url::parse(&git_url_without_query).unwrap(),
-                rev: String::from(revision),
+                rev: revision,
             }
         }
         _ => {
@@ -118,6 +118,13 @@ mod geiger_tests {
             CargoGeigerSerdeSource::Git {
                 url: Url::parse("https://github.com/rust-itertools/itertools.git").unwrap(),
                 rev: String::from("8761fbefb3b209")
+            }
+        ),
+        case(
+            "git+https://github.com/rust-itertools/itertools.git",
+            CargoGeigerSerdeSource::Git {
+                url: Url::parse("https://github.com/rust-itertools/itertools.git").unwrap(),
+                rev: String::from("")
             }
         )
     )]

--- a/cargo-geiger/tests/integration_tests.rs
+++ b/cargo-geiger/tests/integration_tests.rs
@@ -20,7 +20,8 @@ use std::process::Output;
     case("test5_workspace_with_virtual_manifest"),
     case("test6_cargo_lock_out_of_date"),
     case("test7_package_with_patched_dep"),
-    case("test8_package_with_build_rs_no_deps")
+    case("test8_package_with_build_rs_no_deps"),
+    case("test9_package_with_git_deps")
 )]
 fn test_package(name: &str) {
     better_panic::install();

--- a/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stderr.snap
+++ b/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stderr.snap
@@ -1,0 +1,13 @@
+---
+source: cargo-geiger/tests/integration_tests.rs
+expression: stderr
+---
+`{ARTIFACT_JSON_BLOB}`
+`{ARTIFACT_JSON_BLOB}`
+`{ARTIFACT_JSON_BLOB}`
+`{ARTIFACT_JSON_BLOB}`
+`{ARTIFACT_JSON_BLOB}`
+`{ARTIFACT_JSON_BLOB}`
+`{ARTIFACT_JSON_BLOB}`
+`{ARTIFACT_JSON_BLOB}`
+

--- a/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stdout.snap
+++ b/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stdout.snap
@@ -16,7 +16,7 @@ Functions  Expressions  Impls  Traits  Methods  Dependency
 
 0/0        0/0          0/0    0/0     0/0      ?  test9_package_with_git_deps 0.1.0
 0/0        0/72         0/3    0/1     0/3      ?  ├── itertools 0.8.0
-0/0        14/14        0/0    0/0     0/0      ?  │   └── either 1.8.1
+0/0        14/14        0/0    0/0     0/0      !  │   └── either 1.8.1
 0/0        2/2          0/0    0/0     0/0      !  └── ref_slice 1.2.1
 
 0/0        16/88        0/3    0/1     0/3    

--- a/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stdout.snap
+++ b/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stdout.snap
@@ -1,0 +1,24 @@
+---
+source: cargo-geiger/tests/integration_tests.rs
+expression: stdout
+---
+
+Metric output format: x/y
+    x = unsafe code used by the build
+    y = total unsafe code found in the crate
+
+Symbols: 
+    :) = No `unsafe` usage found, declares #![forbid(unsafe_code)]
+    ?  = No `unsafe` usage found, missing #![forbid(unsafe_code)]
+    !  = `unsafe` usage found
+
+Functions  Expressions  Impls  Traits  Methods  Dependency
+
+0/0        0/0          0/0    0/0     0/0      ?  test9_package_with_git_deps 0.1.0
+0/0        0/72         0/3    0/1     0/3      ?  ├── itertools 0.8.0
+0/0        0/14         0/0    0/0     0/0      ?  │   └── either 1.8.1
+0/0        2/2          0/0    0/0     0/0      !  └── ref_slice 1.2.1
+
+0/0        2/88         0/3    0/1     0/3    
+
+

--- a/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stdout.snap
+++ b/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stdout.snap
@@ -16,7 +16,7 @@ Functions  Expressions  Impls  Traits  Methods  Dependency
 
 0/0        0/0          0/0    0/0     0/0      ?  test9_package_with_git_deps 0.1.0
 0/0        0/72         0/3    0/1     0/3      ?  ├── itertools 0.8.0
-0/0        0/14         0/0    0/0     0/0      ?  │   └── either 1.8.1
+0/0        14/14        0/0    0/0     0/0      ?  │   └── either 1.8.1
 0/0        2/2          0/0    0/0     0/0      !  └── ref_slice 1.2.1
 
 0/0        16/88        0/3    0/1     0/3    

--- a/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stdout.snap
+++ b/cargo-geiger/tests/snapshots/integration_tests__test9_package_with_git_deps.stdout.snap
@@ -19,6 +19,6 @@ Functions  Expressions  Impls  Traits  Methods  Dependency
 0/0        0/14         0/0    0/0     0/0      ?  │   └── either 1.8.1
 0/0        2/2          0/0    0/0     0/0      !  └── ref_slice 1.2.1
 
-0/0        2/88         0/3    0/1     0/3    
+0/0        16/88        0/3    0/1     0/3    
 
 

--- a/test_crates/test9_package_with_git_deps/Cargo.toml
+++ b/test_crates/test9_package_with_git_deps/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test9_package_with_git_deps"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+ref_slice = { git = "https://github.com/steveklabnik/ref_slice.git" }
+itertools = { git = "https://github.com/rust-itertools/itertools.git", rev = "8761fbefb3b209" }
+[workspace]

--- a/test_crates/test9_package_with_git_deps/src/lib.rs
+++ b/test_crates/test9_package_with_git_deps/src/lib.rs
@@ -1,0 +1,4 @@
+pub fn g() {
+    println!("Hello");
+}
+


### PR DESCRIPTION
Fixes #461 

- Instead of harsh `unwrap`, a default empty string is used
- Added unit test case for when `rev` is not defined

Is it something like this we want? This is the simplest fix I can come up with, but perhaps it messes with resolution?

Also, do went a debug message, or should this be a silent solution (after all, if there is no `rev` it should have a sane default)

I have yet to figure out the integration tests